### PR TITLE
[KAN-16] chore(alias): alias 설정 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -45,7 +45,7 @@ export default tseslint.config(
       ...react.configs['jsx-runtime'].rules,
       ...reactHooks.configs.recommended.rules,
       ...jsxA11y.configs.recommended.rules,
-      '@typescript-eslint/explicit-module-boundary-types': 'error',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
       'react/jsx-props-no-spreading': 'warn',
       'import/order': [
         'error',
@@ -71,6 +71,20 @@ export default tseslint.config(
       react: { version: 'detect' },
       'import/resolver': {
         node: true,
+      },
+    },
+  },
+  {
+    files: ['vite.config.ts'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        projectService: true,
+        project: './tsconfig.node.json',
+        tsconfigRootDir: import.meta.dirname,
+      },
+      globals: {
+        ...globals.node,
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/node": "^24.3.1",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@typescript-eslint/eslint-plugin": "^8.42.0",
@@ -1497,6 +1498,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
+      "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.10.0"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
@@ -6143,6 +6154,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/node": "^24.3.1",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@typescript-eslint/eslint-plugin": "^8.42.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,19 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useState } from 'react';
+
+import reactLogo from '@/assets/react.svg';
+import viteLogo from '/vite.svg';
+import '@/App.css';
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [count, setCount] = useState(0);
 
   return (
     <>
       <div>
-        <a href="https://vite.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank" rel="noreferrer">
           <img src={viteLogo} className="logo" alt="Vite logo" />
         </a>
-        <a href="https://react.dev" target="_blank">
+        <a href="https://react.dev" target="_blank" rel="noreferrer">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>
@@ -29,7 +30,7 @@ function App() {
         Click on the Vite and React logos to learn more
       </p>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
-import './index.css';
-import App from './App.tsx';
-import GlobalStyles from './styles/GlobalStyles.tsx';
+import '@/index.css';
+import App from '@/App.tsx';
+import GlobalStyles from '@/styles/GlobalStyles.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,11 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
   },
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,10 @@
 {
+  "compilerOptions": {
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { fileURLToPath, URL } from 'node:url';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
## 📄 변경 사항 요약

- tsconfig.json과 tsconfig.app.json에 baseUrl: "src" 및 @/* 경로 별칭을 추가하여 소스 루트에서 절대 경로를 사용할 수 있도록 설정했
- 기존 상대 경로 import를 @/ 별칭으로 변경해 코드 전반에서 일관된 경로 사용이 가능하도록 정리
- Vite 설정에 @ 별칭을 추가하여 빌드 시에도 동일한 절대 경로가 적용되도록 구성
- Vite 설정 파일(vite.config.ts)이 타입 정보를 제공하지 않아 @typescript-eslint/await-thenable 규칙에서 오류가 발생하던 문제를, tsconfig.node.json을 참조하도록 ESLint 설정을 보강해 해결

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #34 

---