### PR TITLE
[KAN-17] chore(font): pretendard 폰트 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@fontsource/pretendard": "^5.2.5",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "styled-reset": "^5.0.0"
@@ -1024,6 +1025,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/pretendard": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/@fontsource/pretendard/-/pretendard-5.2.5.tgz",
+      "integrity": "sha512-UAj3l+Exfx6Sq5hySbhTQhNzkZnhzBxQdHySmjo2lifXyXpMAHv7GD7hAQTLgZfBd1WixJJkmynfJbOp+TAckg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@fontsource/pretendard": "^5.2.5",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "styled-reset": "^5.0.0"

--- a/src/styles/GlobalStyles.tsx
+++ b/src/styles/GlobalStyles.tsx
@@ -1,5 +1,6 @@
 import { Global, css } from '@emotion/react';
 import React from 'react';
+import '@fontsource/pretendard';
 
 // 전부 임시 AI css 코드
 const spacing = {
@@ -27,21 +28,7 @@ const GlobalStyle = (): React.ReactElement => (
       body {
         line-height: 1.5;
         -webkit-font-smoothing: antialiased;
-        font-family:
-          'Pretendard',
-          -apple-system,
-          BlinkMacSystemFont,
-          system-ui,
-          Roboto,
-          'Helvetica Neue',
-          'Segoe UI',
-          'Apple SD Gothic Neo',
-          'Noto Sans KR',
-          'Malgun Gothic',
-          'Apple Color Emoji',
-          'Segoe UI Emoji',
-          'Segoe UI Symbol',
-          sans-serif;
+        font-family: 'Pretendard', sans-serif;
         background-color: #f0f2f5; // 앱 전체 배경색
       }
 

--- a/src/types/fontsource.d.ts
+++ b/src/types/fontsource.d.ts
@@ -1,0 +1,1 @@
+declare module '@fontsource/pretendard';


### PR DESCRIPTION
## 📄 변경 사항 요약

- Pretendard 폰트 전역 적용 (npm install @fontsource/pretendard)
- src/types/fontsource.d.ts에서 Pretendard 모듈을 선언해 TypeScript 모듈 해석 오류를 방지

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #35 

---

