### PR TITLE
[KAN-38] Feature/kan 38 title bar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import InputTextWithEmail from '@/components/inputTextWithEmail';
 import NavigationTab from '@/components/navigationTab';
+import TitleBar from '@/components/titleBar';
 
 import * as S from './App.styled.ts';
 
@@ -15,6 +16,11 @@ function App() {
 
   return (
     <>
+      <TitleBar
+        leftSlot={<button aria-label="back">뒤로</button>}
+        title="타이틀바 예시"
+        rightSlot={<button aria-label="menu">메뉴</button>}
+      />
       <S.Container>
         <NavigationTab tabs={tabs} />
         <InputTextWithEmail

--- a/src/components/titleBar/index.tsx
+++ b/src/components/titleBar/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './titleBar';

--- a/src/components/titleBar/titleBar.styled.ts
+++ b/src/components/titleBar/titleBar.styled.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const Wrapper = styled.header`
+  display: flex;
+  align-items: center;
+  height: ${spacing.spacing14};
+  border-bottom: 1px solid ${colors.border.default};
+`;
+
+export const Slot = styled.div`
+  width: ${spacing.spacing14};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Title = styled.div`
+  flex: 1;
+  text-align: center;
+  color: ${colors.text.default};
+  ${typography.title1Bold};
+  font-size: 1.125rem;
+`;

--- a/src/components/titleBar/titleBar.tsx
+++ b/src/components/titleBar/titleBar.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import * as S from './titleBar.styled';
+
+interface TitleBarProps {
+  leftSlot?: React.ReactNode;
+  title?: string;
+  rightSlot?: React.ReactNode;
+}
+
+const TitleBar = ({ leftSlot, title, rightSlot }: TitleBarProps) => {
+  return (
+    <S.Wrapper>
+      <S.Slot>{leftSlot}</S.Slot>
+      <S.Title>{title}</S.Title>
+      <S.Slot>{rightSlot}</S.Slot>
+    </S.Wrapper>
+  );
+};
+
+export default TitleBar;

--- a/src/tests/titleBar.test.tsx
+++ b/src/tests/titleBar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import TitleBar from '@/components/titleBar';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+describe('TitleBar', () => {
+  it('renders slots and title', () => {
+    render(
+      <TitleBar
+        leftSlot={<button>Left</button>}
+        title="Center"
+        rightSlot={<button>Right</button>}
+      />,
+    );
+    expect(screen.getByText('Left')).toBeInTheDocument();
+    expect(screen.getByText('Center')).toBeInTheDocument();
+    expect(screen.getByText('Right')).toBeInTheDocument();
+  });
+
+  it('applies correct styles', () => {
+    render(<TitleBar title="Center" />);
+    const header = screen.getByRole('banner');
+    expect(header).toHaveStyle(`height: ${spacing.spacing14}`);
+    expect(header).toHaveStyle(
+      `border-bottom: 1px solid ${colors.border.default}`,
+    );
+
+    const title = screen.getByText('Center');
+    expect(title).toHaveStyle(`font-size: 1.125rem`);
+    expect(title).toHaveStyle(
+      `font-weight: ${typography.title1Bold.fontWeight}`,
+    );
+  });
+});


### PR DESCRIPTION
## 📄 변경 사항 요약

- 좌/우 슬롯과 중앙 텍스트를 지원하는 독립된 Emotion 스타일 파일로 분리하여 TitleBar 컴포넌트를 추가하고 테마의 간격, 색상, 타이포그래피를 활용해 스타일을 적용
- App에 TitleBar를 배치하여 간단한 테스트 화면을 제공하고 버튼 슬롯 예시를 포함

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #61 

---

## 📸 스크린샷 또는 동영상
<img width="714" height="53" alt="스크린샷 2025-09-13 022517" src="https://github.com/user-attachments/assets/40fab188-5f28-493c-9307-1d414f31f711" />

---

## 🧪 테스트 방법 

1. 첫 번째 테스트 (renders slots and title)
  Left, Center, Right 텍스트가 DOM에 있는지 확인

2. 두 번째 테스트 (applies correct styles)
  TitleBar 기본 렌더링 후 role이 banner인 요소 가져오기
  스타일 확인:
  높이가 spacing.spacing14인지
  border-bottom이 colors.border.default인지
  중앙 텍스트(Center)의 스타일 확인:
  font-size가 1.125rem인지
  font-weight가 typography.title1Bold.fontWeight인지

---
