### PR TITLE
[KAN-33] feat(logintitlebar): 로그인 타이틀바를 타이틀바를 이용해 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import InputTextWithEmail from '@/components/inputTextWithEmail';
+import LoginTitleBar from '@/components/loginTitleBar';
 import NavigationTab from '@/components/navigationTab';
 import TitleBar from '@/components/titleBar';
 
@@ -21,6 +22,7 @@ function App() {
         title="타이틀바 예시"
         rightSlot={<button aria-label="menu">메뉴</button>}
       />
+      <LoginTitleBar />
       <S.Container>
         <NavigationTab tabs={tabs} />
         <InputTextWithEmail

--- a/src/components/loginTitleBar/index.ts
+++ b/src/components/loginTitleBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './loginTitleBar';

--- a/src/components/loginTitleBar/loginTitleBar.styled.ts
+++ b/src/components/loginTitleBar/loginTitleBar.styled.ts
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+import TitleBar from '@/components/titleBar';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const Wrapper = styled(TitleBar)`
+  background-color: ${colors.background.default};
+  padding: 0 ${spacing.spacing4};
+
+  & > div:nth-of-type(2) {
+    ${typography.title1Bold};
+    color: ${colors.text.default};
+  }
+`;

--- a/src/components/loginTitleBar/loginTitleBar.tsx
+++ b/src/components/loginTitleBar/loginTitleBar.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import * as S from './loginTitleBar.styled';
+
+const LoginTitleBar = () => {
+  return <S.Wrapper title="로그인" />;
+};
+
+export default LoginTitleBar;

--- a/src/components/navigationTab/index.ts
+++ b/src/components/navigationTab/index.ts
@@ -1,2 +1,2 @@
-export { default } from './NavigationTab';
-export * from './NavigationTab';
+export { default } from './navigationTab';
+export * from './navigationTab';

--- a/src/components/navigationTab/navigationTab.tsx
+++ b/src/components/navigationTab/navigationTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import * as S from './NavigationTab.styled.ts';
+import * as S from './navigationTab.styled.ts';
 
 export interface TabItem {
   label: string;

--- a/src/components/titleBar/titleBar.tsx
+++ b/src/components/titleBar/titleBar.tsx
@@ -6,11 +6,12 @@ interface TitleBarProps {
   leftSlot?: React.ReactNode;
   title?: string;
   rightSlot?: React.ReactNode;
+  className?: string;
 }
 
-const TitleBar = ({ leftSlot, title, rightSlot }: TitleBarProps) => {
+const TitleBar = ({ leftSlot, title, rightSlot, className }: TitleBarProps) => {
   return (
-    <S.Wrapper>
+    <S.Wrapper className={className}>
       <S.Slot>{leftSlot}</S.Slot>
       <S.Title>{title}</S.Title>
       <S.Slot>{rightSlot}</S.Slot>

--- a/src/tests/loginTitleBar.test.tsx
+++ b/src/tests/loginTitleBar.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import LoginTitleBar from '@/components/loginTitleBar';
+import { colors } from '@/theme/color';
+import { typography } from '@/theme/typography';
+
+describe('LoginTitleBar', () => {
+  it('제목을 렌더링한다', () => {
+    render(<LoginTitleBar />);
+    expect(screen.getByText('로그인')).toBeInTheDocument();
+  });
+
+  it('좌우 슬롯이 비어 있다', () => {
+    render(<LoginTitleBar />);
+    const header = screen.getByRole('banner');
+    expect(header.firstChild).toBeEmptyDOMElement();
+    expect(header.lastChild).toBeEmptyDOMElement();
+  });
+
+  it('스타일이 적용된다', () => {
+    render(<LoginTitleBar />);
+    const header = screen.getByRole('banner');
+    expect(header).toHaveStyle(
+      `background-color: ${colors.background.default}`,
+    );
+
+    const title = screen.getByText('로그인');
+    expect(title).toHaveStyle(
+      `font-weight: ${typography.title1Bold.fontWeight}`,
+    );
+  });
+});


### PR DESCRIPTION
## 📄 변경 사항 요약

- Base TitleBar를 활용해 로그인 화면 전용 LoginTitleBar 컴포넌트를 추가하고 스타일 분리 및 테마 색상·간격·타이포그래피를 적용.
- TitleBar에 className을 전달할 수 있도록 확장해 외부에서 손쉽게 스타일을 덧입힐 수 있게 함.
- App.tsx에 LoginTitleBar를 배치해 간단한 로그인 화면을 구성.
---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #55 

---

## 📸 스크린샷 또는 동영상 (선택)
<img width="696" height="61" alt="스크린샷 2025-09-13 033759" src="https://github.com/user-attachments/assets/ae8b2112-9b90-432f-a650-8cf90d73f96d" />
---

## 🧪 테스트 방법 (선택)

1. 👉 LoginTitleBar가 "로그인"이라는 텍스트를 정확히 렌더링하는지 확인
2. 👉 TitleBar의 좌측/우측 슬롯이 비어 있는지 확인
3. 👉 Theme(colors, typography)가 적용되었는지 스타일 검사

---
