### PR TITLE
[KAN-34] Feature/kan 34 origin titlebar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,13 @@ import { useState } from 'react';
 import InputTextWithEmail from '@/components/inputTextWithEmail';
 import LoginTitleBar from '@/components/loginTitleBar';
 import NavigationTab from '@/components/navigationTab';
-import TitleBar from '@/components/titleBar';
+import OriginTitleBar from '@/components/originTitleBar';
 
 import * as S from './App.styled.ts';
 
 function App() {
   const [email, setEmail] = useState('');
+  const [backCount, setBackCount] = useState(0);
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
     { label: 'Search', content: <div>Search Content</div> },
@@ -17,13 +18,13 @@ function App() {
 
   return (
     <>
-      <TitleBar
-        leftSlot={<button aria-label="back">뒤로</button>}
-        title="타이틀바 예시"
-        rightSlot={<button aria-label="menu">메뉴</button>}
+      <OriginTitleBar
+        title="오리진 타이틀바"
+        onBack={() => setBackCount((c) => c + 1)}
       />
       <LoginTitleBar />
       <S.Container>
+        <p>Back 클릭 횟수: {backCount}</p>
         <NavigationTab tabs={tabs} />
         <InputTextWithEmail
           helperText="학교 이메일을 입력해주세요."

--- a/src/components/originTitleBar/index.ts
+++ b/src/components/originTitleBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './originTitleBar';

--- a/src/components/originTitleBar/originTitleBar.styled.ts
+++ b/src/components/originTitleBar/originTitleBar.styled.ts
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+import TitleBar from '@/components/titleBar';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const Wrapper = styled(TitleBar)`
+  background-color: ${colors.background.default};
+`;
+
+export const BackButton = styled.button`
+  width: ${spacing.spacing14};
+  height: ${spacing.spacing14};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  color: ${colors.text.default};
+  ${typography.title1Bold};
+  cursor: pointer;
+`;

--- a/src/components/originTitleBar/originTitleBar.tsx
+++ b/src/components/originTitleBar/originTitleBar.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import * as S from './originTitleBar.styled';
+
+interface OriginTitleBarProps {
+  title: string;
+  onBack: () => void;
+  className?: string;
+}
+
+const OriginTitleBar = ({ title, onBack, className }: OriginTitleBarProps) => {
+  return (
+    <S.Wrapper
+      className={className}
+      leftSlot={
+        <S.BackButton onClick={onBack} aria-label="뒤로 가기">
+          ←
+        </S.BackButton>
+      }
+      title={title}
+    />
+  );
+};
+
+export default OriginTitleBar;

--- a/src/tests/originTitleBar.test.tsx
+++ b/src/tests/originTitleBar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import OriginTitleBar from '@/components/originTitleBar';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+describe('OriginTitleBar', () => {
+  it('renders title and back button', () => {
+    const handleBack = vi.fn();
+    render(<OriginTitleBar title="Origin" onBack={handleBack} />);
+
+    const backButton = screen.getByLabelText('뒤로 가기');
+    expect(backButton).toBeInTheDocument();
+    expect(screen.getByText('Origin')).toBeInTheDocument();
+
+    fireEvent.click(backButton);
+    expect(handleBack).toHaveBeenCalled();
+  });
+
+  it('applies styles and has empty right slot', () => {
+    render(<OriginTitleBar title="Origin" onBack={() => {}} />);
+
+    const backButton = screen.getByLabelText('뒤로 가기');
+    expect(backButton).toHaveStyle(`width: ${spacing.spacing14}`);
+    expect(backButton).toHaveStyle(`color: ${colors.text.default}`);
+
+    const title = screen.getByText('Origin');
+    expect(title).toHaveStyle(
+      `font-weight: ${typography.title1Bold.fontWeight}`,
+    );
+
+    const header = screen.getByRole('banner');
+    expect(header.lastChild).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
## 📄 변경 사항 요약

- Base TitleBar를 기반으로 좌측에 ← 버튼과 중앙 제목을 배치한 OriginTitleBar 컴포넌트를 추가하고, 색상·타이포그래피·여백을 테마에서 가져와 스타일을 구성
- App.tsx에 OriginTitleBar 사용 예시와 뒤로가기 횟수를 표시하는 간단한 화면을 구현

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #56 

---

## 📸 스크린샷 또는 동영상 (선택)
<img width="697" height="59" alt="image" src="https://github.com/user-attachments/assets/89cef547-f493-483e-9241-bb798ced0597" />
---

## 🧪 테스트 방법 (선택)

1. 렌더링
title="Origin" 이 잘 뜨는지
aria-label="뒤로 가기" 버튼이 존재하는지
동작
버튼 클릭 시 onBack 핸들러가 호출되는지
2. 스타일
spacing, colors, typography가 적용됐는지
3. 레이아웃
header의 마지막 child가 비어있는지 (우측 슬롯 없음 확인)

---

## 📌 기타 참고 사항
