### PR TITLE
Feature/kan 35 home title bar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fontsource/pretendard": "^5.2.5",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-icons": "^5.5.0",
         "styled-reset": "^5.0.0"
       },
       "devDependencies": {
@@ -7327,6 +7328,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fontsource/pretendard": "^5.2.5",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0",
     "styled-reset": "^5.0.0"
   },
   "devDependencies": {

--- a/src/App.styled.ts
+++ b/src/App.styled.ts
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.spacing3};
+  padding: ${spacing.spacing4};
+`;
+
+export const EmailText = styled.p`
+  margin: 0;
+  ${typography.body1Regular};
+  color: ${colors.text.default};
+`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import HomeTitleBar from '@/components/homeTitleBar';
 import InputTextWithEmail from '@/components/inputTextWithEmail';
 import LoginTitleBar from '@/components/loginTitleBar';
 import NavigationTab from '@/components/navigationTab';
@@ -10,6 +11,8 @@ import * as S from './App.styled.ts';
 function App() {
   const [email, setEmail] = useState('');
   const [backCount, setBackCount] = useState(0);
+  const [menuCount, setMenuCount] = useState(0);
+
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
     { label: 'Search', content: <div>Search Content</div> },
@@ -18,12 +21,17 @@ function App() {
 
   return (
     <>
+      <HomeTitleBar
+        title="홈 타이틀바"
+        onMenu={() => setMenuCount((c) => c + 1)}
+      />
       <OriginTitleBar
         title="오리진 타이틀바"
         onBack={() => setBackCount((c) => c + 1)}
       />
       <LoginTitleBar />
       <S.Container>
+        <p>Profile 클릭 횟수: {menuCount}</p>
         <p>Back 클릭 횟수: {backCount}</p>
         <NavigationTab tabs={tabs} />
         <InputTextWithEmail

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,28 @@
 import { useState } from 'react';
 
-import InputTextWithEmail from '@/components/inputTextWithEmail/index.ts';
+import InputTextWithEmail from '@/components/inputTextWithEmail';
+import NavigationTab from '@/components/navigationTab';
 
 import * as S from './App.styled.ts';
 
 function App() {
   const [email, setEmail] = useState('');
+  const tabs = [
+    { label: 'Home', content: <div>Home Content</div> },
+    { label: 'Search', content: <div>Search Content</div> },
+    { label: 'Profile', content: <div>Profile Content</div> },
+  ];
 
   return (
     <>
       <S.Container>
+        <NavigationTab tabs={tabs} />
         <InputTextWithEmail
           helperText="학교 이메일을 입력해주세요."
           onChange={setEmail}
         />
         <S.EmailText>입력한 이메일: {email}</S.EmailText>
-      </S.Container>{' '}
+      </S.Container>
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,21 @@
+import { useState } from 'react';
+
+import InputTextWithEmail from '@/components/inputTextWithEmail/index.ts';
+
+import * as S from './App.styled.ts';
+
 function App() {
+  const [email, setEmail] = useState('');
+
   return (
     <>
-      <p>P-Ting</p>
+      <S.Container>
+        <InputTextWithEmail
+          helperText="학교 이메일을 입력해주세요."
+          onChange={setEmail}
+        />
+        <S.EmailText>입력한 이메일: {email}</S.EmailText>
+      </S.Container>{' '}
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,12 +3,13 @@ import { useState } from 'react';
 import InputTextWithEmail from '@/components/inputTextWithEmail';
 import LoginTitleBar from '@/components/loginTitleBar';
 import NavigationTab from '@/components/navigationTab';
-import TitleBar from '@/components/titleBar';
+import OriginTitleBar from '@/components/originTitleBar';
 
 import * as S from './App.styled.ts';
 
 function App() {
   const [email, setEmail] = useState('');
+  const [backCount, setBackCount] = useState(0);
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
     { label: 'Search', content: <div>Search Content</div> },
@@ -17,13 +18,13 @@ function App() {
 
   return (
     <>
-      <TitleBar
-        leftSlot={<button aria-label="back">뒤로</button>}
-        title="타이틀바 예시"
-        rightSlot={<button aria-label="menu">메뉴</button>}
+      <OriginTitleBar
+        title="오리진 타이틀바"
+        onBack={() => setBackCount((c) => c + 1)}
       />
       <LoginTitleBar />
       <S.Container>
+        <p>Back 클릭 횟수: {backCount}</p>
         <NavigationTab tabs={tabs} />
         <InputTextWithEmail
           helperText="학교 이메일을 입력해주세요."

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import InputTextWithEmail from '@/components/inputTextWithEmail';
 import NavigationTab from '@/components/navigationTab';
+import TitleBar from '@/components/titleBar';
 
 import * as S from './App.styled.ts';
 
@@ -15,6 +16,11 @@ function App() {
 
   return (
     <>
+      <TitleBar
+        leftSlot={<button aria-label="back">뒤로</button>}
+        title="타이틀바 예시"
+        rightSlot={<button aria-label="menu">메뉴</button>}
+      />
       <S.Container>
         <NavigationTab tabs={tabs} />
         <InputTextWithEmail

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import InputTextWithEmail from '@/components/inputTextWithEmail';
+import LoginTitleBar from '@/components/loginTitleBar';
 import NavigationTab from '@/components/navigationTab';
 import TitleBar from '@/components/titleBar';
 
@@ -21,6 +22,7 @@ function App() {
         title="타이틀바 예시"
         rightSlot={<button aria-label="menu">메뉴</button>}
       />
+      <LoginTitleBar />
       <S.Container>
         <NavigationTab tabs={tabs} />
         <InputTextWithEmail

--- a/src/components/InputTextWithEmail/InputTextWithEmail.tsx
+++ b/src/components/InputTextWithEmail/InputTextWithEmail.tsx
@@ -1,0 +1,86 @@
+import { useState, type ChangeEvent } from 'react';
+
+import * as S from './inputTextWithEmail.styled';
+
+interface InputTextWithEmailProps {
+  value?: string;
+  defaultDomain?: string;
+  helperText?: string;
+  onChange?: (value: string) => void;
+}
+
+const DEFAULT_DOMAIN = 'pusan.ac.kr';
+
+const InputTextWithEmail = ({
+  value,
+  defaultDomain = DEFAULT_DOMAIN,
+  helperText,
+  onChange,
+}: InputTextWithEmailProps) => {
+  const [localPart, setLocalPart] = useState(() => {
+    const [local = ''] = value ? value.split('@') : [''];
+    return local;
+  });
+
+  const initialDomain = value?.split('@')[1];
+  const isCustomInitial = initialDomain && initialDomain !== defaultDomain;
+  const [useCustomDomain, setUseCustomDomain] = useState(!!isCustomInitial);
+  const [domain, setDomain] = useState(
+    isCustomInitial ? (initialDomain ?? '') : defaultDomain,
+  );
+
+  const handleLocalChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const local = e.target.value;
+    setLocalPart(local);
+    onChange?.(`${local}@${domain}`);
+  };
+
+  const handleDomainSelectChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    if (e.target.value === 'other') {
+      setUseCustomDomain(true);
+      setDomain('');
+      onChange?.(`${localPart}@`);
+    } else {
+      setUseCustomDomain(false);
+      setDomain(defaultDomain);
+      onChange?.(`${localPart}@${defaultDomain}`);
+    }
+  };
+
+  const handleDomainInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setDomain(e.target.value);
+    onChange?.(`${localPart}@${e.target.value}`);
+  };
+
+  return (
+    <S.Wrapper>
+      <S.InputArea>
+        <S.LocalInput
+          value={localPart}
+          onChange={handleLocalChange}
+          aria-label="email local part"
+        />
+        <S.AtSign>@</S.AtSign>
+        {useCustomDomain ? (
+          <S.DomainInput
+            value={domain}
+            onChange={handleDomainInputChange}
+            aria-label="email domain input"
+          />
+        ) : (
+          <S.DomainSelect
+            value={defaultDomain}
+            onChange={handleDomainSelectChange}
+            aria-label="email domain select"
+          >
+            <option value={defaultDomain}>{defaultDomain}</option>
+            <option value="other">직접입력</option>
+          </S.DomainSelect>
+        )}
+      </S.InputArea>
+      {helperText && <S.HelperText>{helperText}</S.HelperText>}
+    </S.Wrapper>
+  );
+};
+
+export default InputTextWithEmail;

--- a/src/components/InputTextWithEmail/index.ts
+++ b/src/components/InputTextWithEmail/index.ts
@@ -1,0 +1,2 @@
+export { default } from './inputTextWithEmail';
+export * from './inputTextWithEmail';

--- a/src/components/InputTextWithEmail/inputTextWithEmail.styled.ts
+++ b/src/components/InputTextWithEmail/inputTextWithEmail.styled.ts
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.spacing1};
+`;
+
+export const InputArea = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${spacing.spacing2};
+`;
+
+export const LocalInput = styled.input`
+  flex: 1;
+  padding: ${spacing.spacing2};
+  border: 1px solid ${colors.border.default};
+  border-radius: ${spacing.spacing1};
+  ${typography.body1Regular};
+`;
+
+export const AtSign = styled.span`
+  ${typography.body1Regular};
+  color: ${colors.text.sub};
+`;
+
+export const DomainSelect = styled.select`
+  padding: ${spacing.spacing2};
+  border: 1px solid ${colors.border.default};
+  border-radius: ${spacing.spacing1};
+  ${typography.body1Regular};
+  background-color: ${colors.background.default};
+`;
+
+export const DomainInput = styled.input`
+  padding: ${spacing.spacing2};
+  border: 1px solid ${colors.border.default};
+  border-radius: ${spacing.spacing1};
+  ${typography.body1Regular};
+`;
+
+export const HelperText = styled.p`
+  ${typography.label2Regular};
+  color: ${colors.text.sub};
+  margin: 0;
+  text-align: left;
+`;

--- a/src/components/homeTitleBar/homeTitleBar.styled.ts
+++ b/src/components/homeTitleBar/homeTitleBar.styled.ts
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import { CgProfile } from 'react-icons/cg';
+
+import TitleBar from '@/components/titleBar';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const Wrapper = styled(TitleBar)`
+  background-color: ${colors.background.default};
+  padding: 0 ${spacing.spacing4};
+
+  & > div:nth-of-type(2) {
+    ${typography.title1Bold};
+    color: ${colors.text.default};
+  }
+`;
+
+export const IconButton = styled.button`
+  border: none;
+  background: none;
+  padding: ${spacing.spacing2};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+`;
+export const ProfileIcon = styled(CgProfile)`
+  width: ${spacing.spacing6};
+  height: ${spacing.spacing6};
+  color: ${colors.text.default};
+`;

--- a/src/components/homeTitleBar/homeTitleBar.tsx
+++ b/src/components/homeTitleBar/homeTitleBar.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import * as S from './homeTitleBar.styled';
+
+interface HomeTitleBarProps {
+  title: string;
+  onMenu: () => void;
+}
+
+const HomeTitleBar = ({ title, onMenu }: HomeTitleBarProps) => {
+  return (
+    <S.Wrapper
+      title={title}
+      rightSlot={
+        <S.IconButton aria-label="profile" onClick={onMenu}>
+          <S.ProfileIcon />
+        </S.IconButton>
+      }
+    />
+  );
+};
+
+export default HomeTitleBar;

--- a/src/components/homeTitleBar/index.ts
+++ b/src/components/homeTitleBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './homeTitleBar';

--- a/src/components/loginTitleBar/index.ts
+++ b/src/components/loginTitleBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './loginTitleBar';

--- a/src/components/loginTitleBar/loginTitleBar.styled.ts
+++ b/src/components/loginTitleBar/loginTitleBar.styled.ts
@@ -1,0 +1,16 @@
+import styled from '@emotion/styled';
+
+import TitleBar from '@/components/titleBar';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const Wrapper = styled(TitleBar)`
+  background-color: ${colors.background.default};
+  padding: 0 ${spacing.spacing4};
+
+  & > div:nth-of-type(2) {
+    ${typography.title1Bold};
+    color: ${colors.text.default};
+  }
+`;

--- a/src/components/loginTitleBar/loginTitleBar.tsx
+++ b/src/components/loginTitleBar/loginTitleBar.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import * as S from './loginTitleBar.styled';
+
+const LoginTitleBar = () => {
+  return <S.Wrapper title="로그인" />;
+};
+
+export default LoginTitleBar;

--- a/src/components/navigationTab/index.ts
+++ b/src/components/navigationTab/index.ts
@@ -1,0 +1,2 @@
+export { default } from './NavigationTab';
+export * from './NavigationTab';

--- a/src/components/navigationTab/index.ts
+++ b/src/components/navigationTab/index.ts
@@ -1,2 +1,2 @@
-export { default } from './NavigationTab';
-export * from './NavigationTab';
+export { default } from './navigationTab';
+export * from './navigationTab';

--- a/src/components/navigationTab/navigationTab.styled.ts
+++ b/src/components/navigationTab/navigationTab.styled.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const TabList = styled.nav`
+  display: flex;
+  border-bottom: 1px solid ${colors.border.default};
+`;
+
+export const TabButton = styled.button<{ active: boolean }>`
+  flex: 1;
+  padding: ${spacing.spacing3} ${spacing.spacing4};
+  background: none;
+  border: none;
+  cursor: pointer;
+  ${typography.subtitle1Bold};
+  color: ${({ active }) => (active ? colors.text.default : colors.text.sub)};
+  border-bottom: ${({ active }) =>
+    active ? `2px solid ${colors.brand.kakaoYellow}` : '2px solid transparent'};
+`;
+
+export const TabPanel = styled.div`
+  padding: ${spacing.spacing4};
+  ${typography.body1Regular};
+`;

--- a/src/components/navigationTab/navigationTab.tsx
+++ b/src/components/navigationTab/navigationTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-import * as S from './NavigationTab.styled.ts';
+import * as S from './navigationTab.styled.ts';
 
 export interface TabItem {
   label: string;

--- a/src/components/navigationTab/navigationTab.tsx
+++ b/src/components/navigationTab/navigationTab.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+
+import * as S from './NavigationTab.styled.ts';
+
+export interface TabItem {
+  label: string;
+  content: React.ReactNode;
+}
+
+interface NavigationTabProps {
+  tabs: TabItem[];
+}
+
+const NavigationTab = ({ tabs }: NavigationTabProps) => {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  return (
+    <div>
+      <S.TabList role="tablist">
+        {tabs.map((tab, index) => (
+          <S.TabButton
+            key={tab.label}
+            role="tab"
+            active={activeIndex === index}
+            aria-selected={activeIndex === index}
+            onClick={() => setActiveIndex(index)}
+          >
+            {tab.label}
+          </S.TabButton>
+        ))}
+      </S.TabList>
+      <S.TabPanel role="tabpanel">{tabs[activeIndex]?.content}</S.TabPanel>
+    </div>
+  );
+};
+
+export default NavigationTab;

--- a/src/components/originTitleBar/index.ts
+++ b/src/components/originTitleBar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './originTitleBar';

--- a/src/components/originTitleBar/originTitleBar.styled.ts
+++ b/src/components/originTitleBar/originTitleBar.styled.ts
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+import TitleBar from '@/components/titleBar';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const Wrapper = styled(TitleBar)`
+  background-color: ${colors.background.default};
+`;
+
+export const BackButton = styled.button`
+  width: ${spacing.spacing14};
+  height: ${spacing.spacing14};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  color: ${colors.text.default};
+  ${typography.title1Bold};
+  cursor: pointer;
+`;

--- a/src/components/originTitleBar/originTitleBar.tsx
+++ b/src/components/originTitleBar/originTitleBar.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import * as S from './originTitleBar.styled';
+
+interface OriginTitleBarProps {
+  title: string;
+  onBack: () => void;
+  className?: string;
+}
+
+const OriginTitleBar = ({ title, onBack, className }: OriginTitleBarProps) => {
+  return (
+    <S.Wrapper
+      className={className}
+      leftSlot={
+        <S.BackButton onClick={onBack} aria-label="뒤로 가기">
+          ←
+        </S.BackButton>
+      }
+      title={title}
+    />
+  );
+};
+
+export default OriginTitleBar;

--- a/src/components/titleBar/index.tsx
+++ b/src/components/titleBar/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './titleBar';

--- a/src/components/titleBar/titleBar.styled.ts
+++ b/src/components/titleBar/titleBar.styled.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const Wrapper = styled.header`
+  display: flex;
+  align-items: center;
+  height: ${spacing.spacing14};
+  border-bottom: 1px solid ${colors.border.default};
+`;
+
+export const Slot = styled.div`
+  width: ${spacing.spacing14};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Title = styled.div`
+  flex: 1;
+  text-align: center;
+  color: ${colors.text.default};
+  ${typography.title1Bold};
+  font-size: 1.125rem;
+`;

--- a/src/components/titleBar/titleBar.tsx
+++ b/src/components/titleBar/titleBar.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import * as S from './titleBar.styled';
+
+interface TitleBarProps {
+  leftSlot?: React.ReactNode;
+  title?: string;
+  rightSlot?: React.ReactNode;
+}
+
+const TitleBar = ({ leftSlot, title, rightSlot }: TitleBarProps) => {
+  return (
+    <S.Wrapper>
+      <S.Slot>{leftSlot}</S.Slot>
+      <S.Title>{title}</S.Title>
+      <S.Slot>{rightSlot}</S.Slot>
+    </S.Wrapper>
+  );
+};
+
+export default TitleBar;

--- a/src/components/titleBar/titleBar.tsx
+++ b/src/components/titleBar/titleBar.tsx
@@ -6,11 +6,12 @@ interface TitleBarProps {
   leftSlot?: React.ReactNode;
   title?: string;
   rightSlot?: React.ReactNode;
+  className?: string;
 }
 
-const TitleBar = ({ leftSlot, title, rightSlot }: TitleBarProps) => {
+const TitleBar = ({ leftSlot, title, rightSlot, className }: TitleBarProps) => {
   return (
-    <S.Wrapper>
+    <S.Wrapper className={className}>
       <S.Slot>{leftSlot}</S.Slot>
       <S.Title>{title}</S.Title>
       <S.Slot>{rightSlot}</S.Slot>

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -15,4 +15,9 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('tab', { name: 'Search' }));
     expect(screen.getByText('Search Content')).toBeInTheDocument();
   });
+  it('프로필 버튼 클릭 시 카운트가 증가한다', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: 'profile' }));
+    expect(screen.getByText('Profile 클릭 횟수: 1')).toBeInTheDocument();
+  });
 });

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 
 import App from '@/App';
@@ -7,5 +7,12 @@ describe('App', () => {
   it('renders email input component', () => {
     render(<App />);
     expect(screen.getByLabelText(/email local part/i)).toBeInTheDocument();
+  });
+
+  it('renders navigation tabs and switches content', () => {
+    render(<App />);
+    expect(screen.getByRole('tab', { name: 'Home' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: 'Search' }));
+    expect(screen.getByText('Search Content')).toBeInTheDocument();
   });
 });

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -4,8 +4,8 @@ import { describe, it, expect } from 'vitest';
 import App from '@/App';
 
 describe('App', () => {
-  it('renders P-Ting text', () => {
+  it('renders email input component', () => {
     render(<App />);
-    expect(screen.getByText(/P-Ting/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email local part/i)).toBeInTheDocument();
   });
 });

--- a/src/tests/homeTitleBar.test.tsx
+++ b/src/tests/homeTitleBar.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import HomeTitleBar from '@/components/homeTitleBar';
+import { colors } from '@/theme/color';
+import { typography } from '@/theme/typography';
+
+describe('HomeTitleBar', () => {
+  it('제목을 렌더링한다', () => {
+    render(<HomeTitleBar title="홈" onMenu={() => {}} />);
+    expect(screen.getByText('홈')).toBeInTheDocument();
+  });
+
+  it('좌측 아이콘 버튼이 존재하지 않는다', () => {
+    render(<HomeTitleBar title="홈" onMenu={() => {}} />);
+    expect(screen.queryByRole('button', { name: 'menu' })).toBeNull();
+  });
+
+  it('우측 프로필 아이콘이 렌더링된다', () => {
+    render(<HomeTitleBar title="홈" onMenu={() => {}} />);
+    expect(
+      screen.getByRole('button', { name: 'profile' }).firstChild,
+    ).toBeInTheDocument();
+  });
+
+  it('우측 프로필 버튼 클릭 시 핸들러가 호출된다', () => {
+    const handleMenu = vi.fn();
+    render(<HomeTitleBar title="홈" onMenu={handleMenu} />);
+    fireEvent.click(screen.getByRole('button', { name: 'profile' }));
+    expect(handleMenu).toHaveBeenCalled();
+  });
+
+  it('스타일이 적용된다', () => {
+    render(<HomeTitleBar title="홈" onMenu={() => {}} />);
+    const title = screen.getByText('홈');
+    expect(title).toHaveStyle(
+      `font-weight: ${typography.title1Bold.fontWeight}`,
+    );
+    const profileIcon = screen.getByRole('button', {
+      name: 'profile',
+    }).firstChild;
+    expect(profileIcon).toHaveStyle(`color: ${colors.text.default}`);
+  });
+});

--- a/src/tests/inputTextWithEmail.test.tsx
+++ b/src/tests/inputTextWithEmail.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import InputTextWithEmail from '@/components/inputTextWithEmail';
+
+describe('InputTextWithEmail', () => {
+  it('renders default domain', () => {
+    render(<InputTextWithEmail />);
+    const select = screen.getByLabelText('email domain select');
+    expect(select).toHaveValue('pusan.ac.kr');
+    expect(
+      screen.getByRole('option', { name: '직접입력' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onChange with default domain', () => {
+    const handleChange = vi.fn();
+    render(<InputTextWithEmail onChange={handleChange} />);
+    fireEvent.change(screen.getByLabelText('email local part'), {
+      target: { value: 'test' },
+    });
+    expect(handleChange).toHaveBeenLastCalledWith('test@pusan.ac.kr');
+  });
+
+  it('allows custom domain input', () => {
+    const handleChange = vi.fn();
+    render(<InputTextWithEmail onChange={handleChange} />);
+    fireEvent.change(screen.getByLabelText('email domain select'), {
+      target: { value: 'other' },
+    });
+    fireEvent.change(screen.getByLabelText('email domain input'), {
+      target: { value: 'gmail.com' },
+    });
+    fireEvent.change(screen.getByLabelText('email local part'), {
+      target: { value: 'test' },
+    });
+    expect(handleChange).toHaveBeenLastCalledWith('test@gmail.com');
+  });
+
+  it('shows helper text', () => {
+    render(<InputTextWithEmail helperText="이메일을 입력하세요" />);
+    expect(screen.getByText('이메일을 입력하세요')).toBeInTheDocument();
+  });
+});

--- a/src/tests/loginTitleBar.test.tsx
+++ b/src/tests/loginTitleBar.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import LoginTitleBar from '@/components/loginTitleBar';
+import { colors } from '@/theme/color';
+import { typography } from '@/theme/typography';
+
+describe('LoginTitleBar', () => {
+  it('제목을 렌더링한다', () => {
+    render(<LoginTitleBar />);
+    expect(screen.getByText('로그인')).toBeInTheDocument();
+  });
+
+  it('좌우 슬롯이 비어 있다', () => {
+    render(<LoginTitleBar />);
+    const header = screen.getByRole('banner');
+    expect(header.firstChild).toBeEmptyDOMElement();
+    expect(header.lastChild).toBeEmptyDOMElement();
+  });
+
+  it('스타일이 적용된다', () => {
+    render(<LoginTitleBar />);
+    const header = screen.getByRole('banner');
+    expect(header).toHaveStyle(
+      `background-color: ${colors.background.default}`,
+    );
+
+    const title = screen.getByText('로그인');
+    expect(title).toHaveStyle(
+      `font-weight: ${typography.title1Bold.fontWeight}`,
+    );
+  });
+});

--- a/src/tests/navigationTab.test.tsx
+++ b/src/tests/navigationTab.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import NavigationTab from '@/components/navigationTab';
+import { colors } from '@/theme/color';
+
+describe('NavigationTab', () => {
+  const tabs = [
+    { label: 'Home', content: <div>Home Content</div> },
+    { label: 'Search', content: <div>Search Content</div> },
+    { label: 'Profile', content: <div>Profile Content</div> },
+  ];
+
+  it('renders first tab content by default', () => {
+    render(<NavigationTab tabs={tabs} />);
+    expect(screen.getByText('Home Content')).toBeInTheDocument();
+  });
+
+  it('changes content when a different tab is clicked', () => {
+    render(<NavigationTab tabs={tabs} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Search' }));
+    expect(screen.getByText('Search Content')).toBeInTheDocument();
+  });
+
+  it('highlights only the selected tab', () => {
+    render(<NavigationTab tabs={tabs} />);
+    const searchTab = screen.getByRole('tab', { name: 'Search' });
+    fireEvent.click(searchTab);
+    expect(searchTab).toHaveStyle(`color: ${colors.text.default}`);
+    const homeTab = screen.getByRole('tab', { name: 'Home' });
+    expect(homeTab).toHaveStyle(`color: ${colors.text.sub}`);
+  });
+});

--- a/src/tests/originTitleBar.test.tsx
+++ b/src/tests/originTitleBar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import OriginTitleBar from '@/components/originTitleBar';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+describe('OriginTitleBar', () => {
+  it('renders title and back button', () => {
+    const handleBack = vi.fn();
+    render(<OriginTitleBar title="Origin" onBack={handleBack} />);
+
+    const backButton = screen.getByLabelText('뒤로 가기');
+    expect(backButton).toBeInTheDocument();
+    expect(screen.getByText('Origin')).toBeInTheDocument();
+
+    fireEvent.click(backButton);
+    expect(handleBack).toHaveBeenCalled();
+  });
+
+  it('applies styles and has empty right slot', () => {
+    render(<OriginTitleBar title="Origin" onBack={() => {}} />);
+
+    const backButton = screen.getByLabelText('뒤로 가기');
+    expect(backButton).toHaveStyle(`width: ${spacing.spacing14}`);
+    expect(backButton).toHaveStyle(`color: ${colors.text.default}`);
+
+    const title = screen.getByText('Origin');
+    expect(title).toHaveStyle(
+      `font-weight: ${typography.title1Bold.fontWeight}`,
+    );
+
+    const header = screen.getByRole('banner');
+    expect(header.lastChild).toBeEmptyDOMElement();
+  });
+});

--- a/src/tests/titleBar.test.tsx
+++ b/src/tests/titleBar.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import TitleBar from '@/components/titleBar';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+describe('TitleBar', () => {
+  it('renders slots and title', () => {
+    render(
+      <TitleBar
+        leftSlot={<button>Left</button>}
+        title="Center"
+        rightSlot={<button>Right</button>}
+      />,
+    );
+    expect(screen.getByText('Left')).toBeInTheDocument();
+    expect(screen.getByText('Center')).toBeInTheDocument();
+    expect(screen.getByText('Right')).toBeInTheDocument();
+  });
+
+  it('applies correct styles', () => {
+    render(<TitleBar title="Center" />);
+    const header = screen.getByRole('banner');
+    expect(header).toHaveStyle(`height: ${spacing.spacing14}`);
+    expect(header).toHaveStyle(
+      `border-bottom: 1px solid ${colors.border.default}`,
+    );
+
+    const title = screen.getByText('Center');
+    expect(title).toHaveStyle(`font-size: 1.125rem`);
+    expect(title).toHaveStyle(
+      `font-weight: ${typography.title1Bold.fontWeight}`,
+    );
+  });
+});


### PR DESCRIPTION
## 📄 변경 사항 요약

- Base TitleBar를 활용해 우측 프로필 아이콘 버튼과 중앙 제목을 가진 HomeTitleBar 컴포넌트를 구현했으며, 메뉴 버튼 핸들러를 props로 받도록 구성
- App에서 프로필 클릭 횟수를 상태로 관리하며, 프로필 버튼 클릭 시 카운트가 증가하는 화면과 테스트를 작성
- 의존성 목록에 react-icons를 추가
- react-icons 기반 프로필 아이콘 스타일을 추가하고 테마의 색상·간격 값을 적용

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #57 

---

## 📸 스크린샷 또는 동영상
<img width="718" height="48" alt="image" src="https://github.com/user-attachments/assets/a9354ff6-70da-4c4b-ae13-81d463f1e010" />
---

## 🧪 테스트 방법 
1. "제목을 렌더링한다"
HomeTitleBar를 렌더링했을 때 title="홈"이 잘 화면에 표시되는지 확인.
즉, props.title → DOM에 반영되는지 검증.

2. "좌측 아이콘 버튼이 존재하지 않는다"
HomeTitleBar에 왼쪽 메뉴 버튼이 없어야 한다는 조건 검증.
queryByRole은 해당 요소가 없으면 null 반환 → 통과.

3. "우측 프로필 아이콘이 렌더링된다"
오른쪽에 프로필 아이콘 버튼이 있어야 한다는 테스트.
접근성(aria-label="profile")이 붙은 버튼을 찾고, 그 버튼의 firstChild (아이콘 SVG 같은 것) 존재 여부 확인.

4. "우측 프로필 버튼 클릭 시 핸들러가 호출된다"
onMenu에 vi.fn() (Vitest의 mock 함수) 전달.
프로필 버튼 클릭 시 → handleMenu 호출되는지 확인.
즉, 이벤트 핸들러 연결 여부 테스트.

5. "스타일이 적용된다"
typography와 colors에서 정의된 디자인 토큰이 제대로 적용됐는지 검증.
홈 텍스트에 font-weight가 올바른지 확인.
프로필 아이콘 색상이 colors.text.default와 일치하는지 확인.
---

## 📌 기타 참고 사항
버튼 구현 후 타이틀 바 리팩토링이 필요할 것 같아 버튼 구현 후 진행하겠습니다.