### PR TITLE
feat(commonbutton): 공통 버튼 구현

### DIFF
--- a/src/App.styled.ts
+++ b/src/App.styled.ts
@@ -16,3 +16,9 @@ export const EmailText = styled.p`
   ${typography.body1Regular};
   color: ${colors.text.default};
 `;
+
+export const CountText = styled.p`
+  margin: 0;
+  ${typography.body1Regular};
+  color: ${colors.text.default};
+`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import Button from '@/components/button';
 import HomeTitleBar from '@/components/homeTitleBar';
 import InputTextWithEmail from '@/components/inputTextWithEmail';
 import LoginTitleBar from '@/components/loginTitleBar';
@@ -12,6 +13,8 @@ function App() {
   const [email, setEmail] = useState('');
   const [backCount, setBackCount] = useState(0);
   const [menuCount, setMenuCount] = useState(0);
+  const [count, setCount] = useState(0);
+  const [liked, setLiked] = useState(false);
 
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
@@ -39,6 +42,16 @@ function App() {
           onChange={setEmail}
         />
         <S.EmailText>입력한 이메일: {email}</S.EmailText>
+        <Button onClick={() => setCount((c) => c + 1)}>카운트 증가</Button>
+        <S.CountText>현재 카운트: {count}</S.CountText>
+        <Button
+          variant="icon"
+          ariaLabel="좋아요 토글"
+          pressed={liked}
+          onPressedChange={setLiked}
+        >
+          {liked ? '💙' : '🤍'}
+        </Button>
       </S.Container>
     </>
   );

--- a/src/components/button/button.styled.ts
+++ b/src/components/button/button.styled.ts
@@ -1,0 +1,155 @@
+import { css, keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'text'
+  | 'icon'
+  | 'round'
+  | 'login';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+const variantStyles = {
+  primary: css`
+    background: ${colors.brand.kakaoYellow};
+    color: ${colors.brand.kakaoBrown};
+    &:hover {
+      background: ${colors.brand.kakaoYellowHover};
+    }
+    &:active {
+      background: ${colors.brand.kakaoYellowPressed};
+    }
+  `,
+  secondary: css`
+    background: ${colors.background.fill};
+    color: ${colors.text.default};
+    border: 1px solid ${colors.border.default};
+    &:hover {
+      background: ${colors.gray[100]};
+    }
+    &:active {
+      background: ${colors.gray[200]};
+    }
+  `,
+  text: css`
+    background: transparent;
+    color: ${colors.text.default};
+    padding: 0;
+    &:hover {
+      background: ${colors.background.fill};
+    }
+    &:active {
+      background: ${colors.gray[200]};
+    }
+  `,
+  icon: css`
+    background: transparent;
+    color: ${colors.text.default};
+    padding: ${spacing.spacing2};
+    border-radius: ${spacing.spacing1};
+    &:hover {
+      background: ${colors.background.fill};
+    }
+    &:active {
+      background: ${colors.gray[200]};
+    }
+  `,
+  round: css`
+    background: ${colors.brand.kakaoYellow};
+    color: ${colors.brand.kakaoBrown};
+    border-radius: 50%;
+    padding: ${spacing.spacing3};
+    &:hover {
+      background: ${colors.brand.kakaoYellowHover};
+    }
+    &:active {
+      background: ${colors.brand.kakaoYellowPressed};
+    }
+  `,
+  login: css`
+    background: ${colors.brand.kakaoYellow};
+    color: ${colors.brand.kakaoBrown};
+    ${typography.subtitle1Bold};
+    &:hover {
+      background: ${colors.brand.kakaoYellowHover};
+    }
+    &:active {
+      background: ${colors.brand.kakaoYellowPressed};
+    }
+  `,
+} as const;
+
+const sizeStyles = {
+  sm: css`
+    padding: ${spacing.spacing2} ${spacing.spacing3};
+    ${typography.body2Bold};
+  `,
+  md: css`
+    padding: ${spacing.spacing3} ${spacing.spacing4};
+    ${typography.body1Bold};
+  `,
+  lg: css`
+    padding: ${spacing.spacing4} ${spacing.spacing6};
+    ${typography.title2Bold};
+  `,
+} as const;
+
+export const StyledButton = styled.button<{
+  variant: ButtonVariant;
+  size: ButtonSize;
+}>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+  ${typography.body1Bold};
+
+  ${({ size }) => sizeStyles[size]};
+  ${({ variant }) => variantStyles[variant]};
+
+  &:focus-visible {
+    outline: 2px solid ${colors.status.info};
+    outline-offset: 2px;
+  }
+
+  &[disabled],
+  &[data-loading='true'] {
+    cursor: not-allowed;
+    opacity: 0.6;
+    pointer-events: none;
+  }
+
+  &[disabled]:hover,
+  &[data-loading='true']:hover,
+  &[disabled]:active,
+  &[data-loading='true']:active {
+    background: inherit;
+  }
+
+  &[aria-pressed='true'] {
+    box-shadow: inset 0 0 0 2px ${colors.border.default};
+    filter: saturate(1.05);
+  }
+`;
+
+const spin = keyframes`
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+export const Spinner = styled.div`
+  width: 1em;
+  height: 1em;
+  border: 2px solid ${colors.background.fill};
+  border-top-color: ${colors.text.sub};
+  border-radius: 50%;
+  animation: ${spin} 0.6s linear infinite;
+`;

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,0 +1,73 @@
+import type {
+  ComponentPropsWithoutRef,
+  MouseEventHandler,
+  ReactNode,
+} from 'react';
+
+import * as S from './button.styled';
+
+export interface ButtonOwnProps {
+  variant?: S.ButtonVariant;
+  size?: S.ButtonSize;
+  loading?: boolean;
+  disabled?: boolean;
+  ariaLabel?: string; // icon 변형이면 필수
+  pressed?: boolean; // 토글 상태
+  onPressedChange?: (v: boolean) => void; // 토글 핸들러(선택)
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  children?: ReactNode;
+}
+
+export type ButtonProps = ButtonOwnProps &
+  Omit<ComponentPropsWithoutRef<'button'>, keyof ButtonOwnProps | 'type'>;
+
+const Button = ({
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  loading = false,
+  ariaLabel,
+  pressed,
+  onPressedChange,
+  onClick,
+  children,
+  ...rest
+}: ButtonProps) => {
+  if (variant === 'icon' && !ariaLabel) {
+    console.warn(
+      '[Button] `icon` variant requires `ariaLabel` for accessibility.',
+    );
+  }
+
+  const isDisabled = disabled || loading;
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (e) => {
+    onClick?.(e);
+    if (!isDisabled && typeof pressed === 'boolean' && onPressedChange) {
+      onPressedChange(!pressed);
+    }
+  };
+
+  return (
+    <S.StyledButton
+      type="button"
+      variant={variant}
+      size={size}
+      disabled={isDisabled}
+      aria-label={ariaLabel}
+      aria-busy={loading || undefined}
+      aria-pressed={typeof pressed === 'boolean' ? pressed : undefined}
+      data-loading={loading ? 'true' : undefined}
+      onClick={handleClick}
+      {...rest}
+    >
+      {loading ? (
+        <S.Spinner role="status" aria-live="polite" aria-label="loading" />
+      ) : (
+        children
+      )}
+    </S.StyledButton>
+  );
+};
+
+export default Button;

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,0 +1,2 @@
+export { default } from './button';
+export * from './button';

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -20,4 +20,17 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: 'profile' }));
     expect(screen.getByText('Profile 클릭 횟수: 1')).toBeInTheDocument();
   });
+
+  it('increments count when button is clicked', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: '카운트 증가' }));
+    expect(screen.getByText('현재 카운트: 1')).toBeInTheDocument();
+  });
+
+  it('toggles like button', () => {
+    render(<App />);
+    const btn = screen.getByRole('button', { name: '좋아요 토글' });
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
 });

--- a/src/tests/button.test.tsx
+++ b/src/tests/button.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import Button from '@/components/button';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button>버튼</Button>);
+    expect(screen.getByRole('button', { name: '버튼' })).toBeInTheDocument();
+  });
+
+  it('handles click event', () => {
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>클릭</Button>);
+    fireEvent.click(screen.getByRole('button', { name: '클릭' }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<Button disabled>비활성</Button>);
+    expect(screen.getByRole('button', { name: '비활성' })).toBeDisabled();
+  });
+
+  it('passes through arbitrary aria attributes', () => {
+    render(
+      <Button aria-label="more" aria-describedby="tip">
+        텍스트
+      </Button>,
+    );
+    expect(screen.getByRole('button', { name: 'more' })).toHaveAttribute(
+      'aria-describedby',
+      'tip',
+    );
+  });
+
+  it('toggles pressed state', () => {
+    const handleChange = vi.fn();
+    render(
+      <Button
+        variant="icon"
+        ariaLabel="좋아요"
+        pressed={false}
+        onPressedChange={handleChange}
+      >
+        🤍
+      </Button>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '좋아요' }));
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('shows spinner and sets aria-busy when loading', () => {
+    render(<Button loading ariaLabel="로딩 버튼" />);
+    const btn = screen.getByRole('button', { name: '로딩 버튼' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+  });
+
+  it('applies primary variant styles', () => {
+    render(<Button variant="primary">스타일</Button>);
+    expect(screen.getByRole('button', { name: '스타일' })).toHaveStyle(
+      `background: ${colors.brand.kakaoYellow}`,
+    );
+  });
+
+  it('applies lg size padding', () => {
+    render(<Button size="lg">큰 버튼</Button>);
+    expect(screen.getByRole('button', { name: '큰 버튼' })).toHaveStyle(
+      `padding: ${spacing.spacing4} ${spacing.spacing6}`,
+    );
+  });
+});


### PR DESCRIPTION
## 📄 변경 사항 요약

- 테마 색상·타이포그래피·간격 토큰을 활용해 primary·secondary·text·icon·round·login 변형과 sm·md·lg 크기를 지원하고 로딩 스피너까지 포함하는 공통 Button 컴포넌트를 구현
- Button 컴포넌트가 표준 버튼 속성을 모두 전달하고 pressed 토글 상태를 지원하도록 확장했으며, 로딩 시 aria-busy와 스피너를 표시
- 스타일 레이어에 포커스 링·비활성/로딩 상태·토글 상태(pressed) 시각화를 추가해 접근성과 피드백을 강화
- App 예제에 아이콘 토글 버튼을 넣어 실제 토글 동작을 확인할 수 있게 함.

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #67 

---

## 📸 스크린샷 또는 동영상 (선택)

https://github.com/user-attachments/assets/13807c87-4ad4-4df7-bffb-b5a84f660d21


---

## 🧪 테스트 방법

(1) renders children
버튼 안의 텍스트(버튼)가 정상적으로 렌더링 되는지 확인.

(2) handles click event
버튼을 클릭했을 때 onClick 핸들러가 호출되는지 확인.

(3) is disabled when disabled prop is set
disabled 속성을 주면 버튼이 비활성화(disabled) 상태인지 확인.

(4) passes through arbitrary aria attributes
접근성 속성(aria-*)이 버튼에 잘 전달되는지 확인.

(5) toggles pressed state
pressed 상태를 토글할 수 있는 버튼(토글 버튼)인지 확인.
클릭 시 onPressedChange(true)가 호출되는지 확인.

(6) shows spinner and sets aria-busy when loading
로딩 중일 때 aria-busy 속성이 붙는지, 로딩 스피너(상태 표시)가 보이는지 확인.

(7) applies primary variant styles
variant="primary"일 때 지정된 색상이 적용되는지 확인.

(8) applies lg size padding
size="lg"일 때 패딩 값이 올바르게 적용되는지 확인.
---

## 📌 기타 참고 사항
