### PR TITLE
Feature/kan 42 text button

### DIFF
--- a/src/App.styled.ts
+++ b/src/App.styled.ts
@@ -16,3 +16,9 @@ export const EmailText = styled.p`
   ${typography.body1Regular};
   color: ${colors.text.default};
 `;
+
+export const CountText = styled.p`
+  margin: 0;
+  ${typography.body1Regular};
+  color: ${colors.text.default};
+`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import Button from '@/components/button';
 import HomeTitleBar from '@/components/homeTitleBar';
 import InputTextWithEmail from '@/components/inputTextWithEmail';
+import LoginButton from '@/components/loginButton';
 import LoginTitleBar from '@/components/loginTitleBar';
 import NavigationTab from '@/components/navigationTab';
 import OriginTitleBar from '@/components/originTitleBar';
@@ -15,6 +16,7 @@ function App() {
   const [menuCount, setMenuCount] = useState(0);
   const [count, setCount] = useState(0);
   const [liked, setLiked] = useState(false);
+  const [loginLoading, setLoginLoading] = useState(false);
 
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
@@ -52,6 +54,14 @@ function App() {
         >
           {liked ? '💙' : '🤍'}
         </Button>
+        <LoginButton
+          ariaLabel="카카오 로그인"
+          loading={loginLoading}
+          onClick={() => {
+            setLoginLoading(true);
+            setTimeout(() => setLoginLoading(false), 1000);
+          }}
+        />
       </S.Container>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import Button from '@/components/button';
 import HomeTitleBar from '@/components/homeTitleBar';
 import InputTextWithEmail from '@/components/inputTextWithEmail';
 import LoginTitleBar from '@/components/loginTitleBar';
@@ -12,6 +13,8 @@ function App() {
   const [email, setEmail] = useState('');
   const [backCount, setBackCount] = useState(0);
   const [menuCount, setMenuCount] = useState(0);
+  const [count, setCount] = useState(0);
+  const [liked, setLiked] = useState(false);
 
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
@@ -39,6 +42,16 @@ function App() {
           onChange={setEmail}
         />
         <S.EmailText>입력한 이메일: {email}</S.EmailText>
+        <Button onClick={() => setCount((c) => c + 1)}>카운트 증가</Button>
+        <S.CountText>현재 카운트: {count}</S.CountText>
+        <Button
+          variant="icon"
+          ariaLabel="좋아요 토글"
+          pressed={liked}
+          onPressedChange={setLiked}
+        >
+          {liked ? '💙' : '🤍'}
+        </Button>
       </S.Container>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import LoginButton from '@/components/loginButton';
 import LoginTitleBar from '@/components/loginTitleBar';
 import NavigationTab from '@/components/navigationTab';
 import OriginTitleBar from '@/components/originTitleBar';
+import TextButton from '@/components/textButton';
 
 import * as S from './App.styled.ts';
 
@@ -17,6 +18,9 @@ function App() {
   const [count, setCount] = useState(0);
   const [liked, setLiked] = useState(false);
   const [loginLoading, setLoginLoading] = useState(false);
+  const [textCount, setTextCount] = useState(0);
+  const [textLiked, setTextLiked] = useState(false);
+  const [textLoading, setTextLoading] = useState(false);
 
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
@@ -62,6 +66,28 @@ function App() {
             setTimeout(() => setLoginLoading(false), 1000);
           }}
         />
+        <TextButton onClick={() => setTextCount((c) => c + 1)}>
+          텍스트 증가
+        </TextButton>
+        <S.CountText>텍스트 카운트: {textCount}</S.CountText>
+        <TextButton
+          ariaLabel="텍스트 좋아요"
+          pressed={textLiked}
+          onPressedChange={setTextLiked}
+        >
+          {textLiked ? 'ON' : 'OFF'}
+        </TextButton>
+        <TextButton
+          ariaLabel="텍스트 로딩 버튼"
+          loading={textLoading}
+          onClick={() => {
+            setTextLoading(true);
+            setTimeout(() => setTextLoading(false), 1000);
+          }}
+        >
+          로딩
+        </TextButton>
+        <TextButton disabled>비활성 텍스트</TextButton>
       </S.Container>
     </>
   );

--- a/src/components/button/button.styled.ts
+++ b/src/components/button/button.styled.ts
@@ -1,0 +1,155 @@
+import { css, keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'text'
+  | 'icon'
+  | 'round'
+  | 'login';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+const variantStyles = {
+  primary: css`
+    background: ${colors.brand.kakaoYellow};
+    color: ${colors.brand.kakaoBrown};
+    &:hover {
+      background: ${colors.brand.kakaoYellowHover};
+    }
+    &:active {
+      background: ${colors.brand.kakaoYellowPressed};
+    }
+  `,
+  secondary: css`
+    background: ${colors.background.fill};
+    color: ${colors.text.default};
+    border: 1px solid ${colors.border.default};
+    &:hover {
+      background: ${colors.gray[100]};
+    }
+    &:active {
+      background: ${colors.gray[200]};
+    }
+  `,
+  text: css`
+    background: transparent;
+    color: ${colors.text.default};
+    padding: 0;
+    &:hover {
+      background: ${colors.background.fill};
+    }
+    &:active {
+      background: ${colors.gray[200]};
+    }
+  `,
+  icon: css`
+    background: transparent;
+    color: ${colors.text.default};
+    padding: ${spacing.spacing2};
+    border-radius: ${spacing.spacing1};
+    &:hover {
+      background: ${colors.background.fill};
+    }
+    &:active {
+      background: ${colors.gray[200]};
+    }
+  `,
+  round: css`
+    background: ${colors.brand.kakaoYellow};
+    color: ${colors.brand.kakaoBrown};
+    border-radius: 50%;
+    padding: ${spacing.spacing3};
+    &:hover {
+      background: ${colors.brand.kakaoYellowHover};
+    }
+    &:active {
+      background: ${colors.brand.kakaoYellowPressed};
+    }
+  `,
+  login: css`
+    background: ${colors.brand.kakaoYellow};
+    color: ${colors.brand.kakaoBrown};
+    ${typography.subtitle1Bold};
+    &:hover {
+      background: ${colors.brand.kakaoYellowHover};
+    }
+    &:active {
+      background: ${colors.brand.kakaoYellowPressed};
+    }
+  `,
+} as const;
+
+const sizeStyles = {
+  sm: css`
+    padding: ${spacing.spacing2} ${spacing.spacing3};
+    ${typography.body2Bold};
+  `,
+  md: css`
+    padding: ${spacing.spacing3} ${spacing.spacing4};
+    ${typography.body1Bold};
+  `,
+  lg: css`
+    padding: ${spacing.spacing4} ${spacing.spacing6};
+    ${typography.title2Bold};
+  `,
+} as const;
+
+export const StyledButton = styled.button<{
+  variant: ButtonVariant;
+  size: ButtonSize;
+}>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+  ${typography.body1Bold};
+
+  ${({ size }) => sizeStyles[size]};
+  ${({ variant }) => variantStyles[variant]};
+
+  &:focus-visible {
+    outline: 2px solid ${colors.status.info};
+    outline-offset: 2px;
+  }
+
+  &[disabled],
+  &[data-loading='true'] {
+    cursor: not-allowed;
+    opacity: 0.6;
+    pointer-events: none;
+  }
+
+  &[disabled]:hover,
+  &[data-loading='true']:hover,
+  &[disabled]:active,
+  &[data-loading='true']:active {
+    background: inherit;
+  }
+
+  &[aria-pressed='true'] {
+    box-shadow: inset 0 0 0 2px ${colors.border.default};
+    filter: saturate(1.05);
+  }
+`;
+
+const spin = keyframes`
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+export const Spinner = styled.div`
+  width: 1em;
+  height: 1em;
+  border: 2px solid ${colors.background.fill};
+  border-top-color: ${colors.text.sub};
+  border-radius: 50%;
+  animation: ${spin} 0.6s linear infinite;
+`;

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,0 +1,73 @@
+import type {
+  ComponentPropsWithoutRef,
+  MouseEventHandler,
+  ReactNode,
+} from 'react';
+
+import * as S from './button.styled';
+
+export interface ButtonOwnProps {
+  variant?: S.ButtonVariant;
+  size?: S.ButtonSize;
+  loading?: boolean;
+  disabled?: boolean;
+  ariaLabel?: string; // icon 변형이면 필수
+  pressed?: boolean; // 토글 상태
+  onPressedChange?: (v: boolean) => void; // 토글 핸들러(선택)
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  children?: ReactNode;
+}
+
+export type ButtonProps = ButtonOwnProps &
+  Omit<ComponentPropsWithoutRef<'button'>, keyof ButtonOwnProps | 'type'>;
+
+const Button = ({
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  loading = false,
+  ariaLabel,
+  pressed,
+  onPressedChange,
+  onClick,
+  children,
+  ...rest
+}: ButtonProps) => {
+  if (variant === 'icon' && !ariaLabel) {
+    console.warn(
+      '[Button] `icon` variant requires `ariaLabel` for accessibility.',
+    );
+  }
+
+  const isDisabled = disabled || loading;
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (e) => {
+    onClick?.(e);
+    if (!isDisabled && typeof pressed === 'boolean' && onPressedChange) {
+      onPressedChange(!pressed);
+    }
+  };
+
+  return (
+    <S.StyledButton
+      type="button"
+      variant={variant}
+      size={size}
+      disabled={isDisabled}
+      aria-label={ariaLabel}
+      aria-busy={loading || undefined}
+      aria-pressed={typeof pressed === 'boolean' ? pressed : undefined}
+      data-loading={loading ? 'true' : undefined}
+      onClick={handleClick}
+      {...rest}
+    >
+      {loading ? (
+        <S.Spinner role="status" aria-live="polite" aria-label="loading" />
+      ) : (
+        children
+      )}
+    </S.StyledButton>
+  );
+};
+
+export default Button;

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,0 +1,2 @@
+export { default } from './button';
+export * from './button';

--- a/src/components/loginButton/index.ts
+++ b/src/components/loginButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './loginButton.tsx';
+export type { LoginButtonProps } from './loginButton.tsx';

--- a/src/components/loginButton/loginButton.styled.ts
+++ b/src/components/loginButton/loginButton.styled.ts
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+import Button from '@/components/button';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const StyledLoginButton = styled(Button)`
+  width: 100%;
+  ${typography.subtitle1Bold};
+  padding: ${spacing.spacing3} ${spacing.spacing4};
+  background: ${colors.brand.kakaoYellow};
+  color: ${colors.brand.kakaoBrown};
+
+  &:hover {
+    background: ${colors.brand.kakaoYellowHover};
+  }
+
+  &:active {
+    background: ${colors.brand.kakaoYellowPressed};
+  }
+`;

--- a/src/components/loginButton/loginButton.tsx
+++ b/src/components/loginButton/loginButton.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+import type { ButtonProps } from '@/components/button/button';
+
+import * as S from './loginButton.styled';
+
+export interface LoginButtonProps
+  extends Omit<ButtonProps, 'variant' | 'children'> {
+  children?: ReactNode;
+}
+
+const LoginButton = ({
+  children = '카카오로 시작하기',
+  ...rest
+}: LoginButtonProps) => {
+  return (
+    <S.StyledLoginButton variant="login" {...rest}>
+      {children}
+    </S.StyledLoginButton>
+  );
+};
+
+export default LoginButton;

--- a/src/components/textButton/index.ts
+++ b/src/components/textButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './textButton';
+export * from './textButton';

--- a/src/components/textButton/textButton.styled.ts
+++ b/src/components/textButton/textButton.styled.ts
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+import Button from '@/components/button';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const StyledTextButton = styled(Button)`
+  ${typography.body2Bold};
+  padding: ${spacing.spacing2} ${spacing.spacing4};
+  color: ${colors.text.default};
+  background: transparent;
+  border-radius: ${spacing.spacing1};
+
+  &:hover {
+    background: ${colors.background.fill};
+  }
+
+  &:active {
+    background: ${colors.gray[200]};
+  }
+`;

--- a/src/components/textButton/textButton.tsx
+++ b/src/components/textButton/textButton.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+import type { ButtonProps } from '@/components/button/button';
+
+import * as S from './textButton.styled';
+
+export interface TextButtonProps extends Omit<ButtonProps, 'variant'> {
+  children?: ReactNode;
+}
+
+const TextButton = ({ children, ...rest }: TextButtonProps) => {
+  return (
+    <S.StyledTextButton variant="text" {...rest}>
+      {children}
+    </S.StyledTextButton>
+  );
+};
+
+export default TextButton;

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -20,4 +20,17 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: 'profile' }));
     expect(screen.getByText('Profile 클릭 횟수: 1')).toBeInTheDocument();
   });
+
+  it('increments count when button is clicked', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: '카운트 증가' }));
+    expect(screen.getByText('현재 카운트: 1')).toBeInTheDocument();
+  });
+
+  it('toggles like button', () => {
+    render(<App />);
+    const btn = screen.getByRole('button', { name: '좋아요 토글' });
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
 });

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -33,4 +33,10 @@ describe('App', () => {
     fireEvent.click(btn);
     expect(btn).toHaveAttribute('aria-pressed', 'true');
   });
+
+  it('increments text count when TextButton is clicked', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: '텍스트 증가' }));
+    expect(screen.getByText('텍스트 카운트: 1')).toBeInTheDocument();
+  });
 });

--- a/src/tests/button.test.tsx
+++ b/src/tests/button.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import Button from '@/components/button';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button>버튼</Button>);
+    expect(screen.getByRole('button', { name: '버튼' })).toBeInTheDocument();
+  });
+
+  it('handles click event', () => {
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>클릭</Button>);
+    fireEvent.click(screen.getByRole('button', { name: '클릭' }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<Button disabled>비활성</Button>);
+    expect(screen.getByRole('button', { name: '비활성' })).toBeDisabled();
+  });
+
+  it('passes through arbitrary aria attributes', () => {
+    render(
+      <Button aria-label="more" aria-describedby="tip">
+        텍스트
+      </Button>,
+    );
+    expect(screen.getByRole('button', { name: 'more' })).toHaveAttribute(
+      'aria-describedby',
+      'tip',
+    );
+  });
+
+  it('toggles pressed state', () => {
+    const handleChange = vi.fn();
+    render(
+      <Button
+        variant="icon"
+        ariaLabel="좋아요"
+        pressed={false}
+        onPressedChange={handleChange}
+      >
+        🤍
+      </Button>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '좋아요' }));
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('shows spinner and sets aria-busy when loading', () => {
+    render(<Button loading ariaLabel="로딩 버튼" />);
+    const btn = screen.getByRole('button', { name: '로딩 버튼' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+  });
+
+  it('applies primary variant styles', () => {
+    render(<Button variant="primary">스타일</Button>);
+    expect(screen.getByRole('button', { name: '스타일' })).toHaveStyle(
+      `background: ${colors.brand.kakaoYellow}`,
+    );
+  });
+
+  it('applies lg size padding', () => {
+    render(<Button size="lg">큰 버튼</Button>);
+    expect(screen.getByRole('button', { name: '큰 버튼' })).toHaveStyle(
+      `padding: ${spacing.spacing4} ${spacing.spacing6}`,
+    );
+  });
+});

--- a/src/tests/loginButton.test.tsx
+++ b/src/tests/loginButton.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import LoginButton from '@/components/loginButton';
+import { colors } from '@/theme/color';
+
+describe('LoginButton', () => {
+  it('renders default text', () => {
+    render(<LoginButton />);
+    expect(
+      screen.getByRole('button', { name: '카카오로 시작하기' }),
+    ).toBeInTheDocument();
+  });
+
+  it('allows overriding children', () => {
+    render(<LoginButton>다른 텍스트</LoginButton>);
+    expect(
+      screen.getByRole('button', { name: '다른 텍스트' }),
+    ).toBeInTheDocument();
+  });
+
+  it('handles click', () => {
+    const handleClick = vi.fn();
+    render(<LoginButton onClick={handleClick} />);
+    fireEvent.click(screen.getByRole('button', { name: '카카오로 시작하기' }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<LoginButton disabled />);
+    expect(
+      screen.getByRole('button', { name: '카카오로 시작하기' }),
+    ).toBeDisabled();
+  });
+
+  it('shows spinner and sets aria-busy when loading', () => {
+    render(<LoginButton loading ariaLabel="로그인" />);
+    const btn = screen.getByRole('button', { name: '로그인' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+  });
+
+  it('toggles pressed state', () => {
+    const handleChange = vi.fn();
+    render(
+      <LoginButton
+        ariaLabel="로그인 토글"
+        pressed={false}
+        onPressedChange={handleChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '로그인 토글' }));
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('applies login variant styles', () => {
+    render(<LoginButton>로그인</LoginButton>);
+    expect(screen.getByRole('button', { name: '로그인' })).toHaveStyle(
+      `background: ${colors.brand.kakaoYellow}`,
+    );
+  });
+});

--- a/src/tests/textButton.test.tsx
+++ b/src/tests/textButton.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import TextButton from '@/components/textButton';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+
+describe('TextButton', () => {
+  it('renders children', () => {
+    render(<TextButton>텍스트</TextButton>);
+    expect(screen.getByRole('button', { name: '텍스트' })).toBeInTheDocument();
+  });
+
+  it('handles click event', () => {
+    const handleClick = vi.fn();
+    render(<TextButton onClick={handleClick}>클릭</TextButton>);
+    fireEvent.click(screen.getByRole('button', { name: '클릭' }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('applies default text styles', () => {
+    render(<TextButton>스타일</TextButton>);
+    expect(screen.getByRole('button', { name: '스타일' })).toHaveStyle(
+      `background: transparent; padding: ${spacing.spacing2} ${spacing.spacing4}; color: ${colors.text.default}`,
+    );
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<TextButton disabled>비활성</TextButton>);
+    expect(screen.getByRole('button', { name: '비활성' })).toBeDisabled();
+  });
+
+  it('shows spinner and sets aria-busy when loading', () => {
+    render(<TextButton loading ariaLabel="로딩" />);
+    const btn = screen.getByRole('button', { name: '로딩' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+  });
+
+  it('toggles pressed state', () => {
+    const handle = vi.fn();
+    render(
+      <TextButton ariaLabel="토글" pressed={false} onPressedChange={handle} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '토글' }));
+    expect(handle).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
## 📄 변경 사항 요약

- 공통 Button을 기반으로 variant 기본값을 “text”로 둔 TextButton 컴포넌트를 추가하고, 테마의 색상·타이포·스페이싱 토큰을 활용한 별도 스타일 파일을 작성
- App 화면에 TextButton 예제를 배치하여 클릭 카운트, 토글, 로딩, 비활성 등 다양한 상태를 직접 확인할 수 있도록 구성

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #70 

---

## 📸 스크린샷 또는 동영상 (선택)

https://github.com/user-attachments/assets/407275b4-d27c-4f73-bc55-306e98055731

--

## 🧪 테스트 방법 

(1) renders children
버튼 안의 텍스트(children)가 제대로 렌더링 되는지 확인.

(2) handles click event
버튼 클릭 시 onClick 핸들러가 실행되는지 확인.

(3) applies default text styles
텍스트 버튼이 갖는 기본 스타일이 적용되는지 확인:
배경은 transparent
패딩은 spacing2 spacing4
글자색은 colors.text.default

(4) is disabled when disabled prop is set
disabled 속성을 주면 버튼이 비활성화되는지 확인.

(5) shows spinner and sets aria-busy when loading
loading 상태일 때:
접근성 속성 aria-busy="true"가 추가되는지
로딩 스피너(role="status", 이름: "loading")가 표시되는지 확인.

(6) toggles pressed state
버튼이 토글 가능할 때, 클릭 시 pressed=false → true로 바뀌고,
onPressedChange(true) 콜백이 실행되는지 확인.
---
