### PR TITLE
Feature/kan 43 icon button

### DIFF
--- a/src/App.styled.ts
+++ b/src/App.styled.ts
@@ -16,3 +16,9 @@ export const EmailText = styled.p`
   ${typography.body1Regular};
   color: ${colors.text.default};
 `;
+
+export const CountText = styled.p`
+  margin: 0;
+  ${typography.body1Regular};
+  color: ${colors.text.default};
+`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import Button from '@/components/button';
 import HomeTitleBar from '@/components/homeTitleBar';
 import InputTextWithEmail from '@/components/inputTextWithEmail';
+import LoginButton from '@/components/loginButton';
 import LoginTitleBar from '@/components/loginTitleBar';
 import NavigationTab from '@/components/navigationTab';
 import OriginTitleBar from '@/components/originTitleBar';
@@ -15,6 +16,7 @@ function App() {
   const [menuCount, setMenuCount] = useState(0);
   const [count, setCount] = useState(0);
   const [liked, setLiked] = useState(false);
+  const [loginLoading, setLoginLoading] = useState(false);
 
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
@@ -52,6 +54,14 @@ function App() {
         >
           {liked ? '💙' : '🤍'}
         </Button>
+        <LoginButton
+          ariaLabel="카카오 로그인"
+          loading={loginLoading}
+          onClick={() => {
+            setLoginLoading(true);
+            setTimeout(() => setLoginLoading(false), 1000);
+          }}
+        />
       </S.Container>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import Button from '@/components/button';
 import HomeTitleBar from '@/components/homeTitleBar';
 import InputTextWithEmail from '@/components/inputTextWithEmail';
 import LoginTitleBar from '@/components/loginTitleBar';
@@ -12,6 +13,8 @@ function App() {
   const [email, setEmail] = useState('');
   const [backCount, setBackCount] = useState(0);
   const [menuCount, setMenuCount] = useState(0);
+  const [count, setCount] = useState(0);
+  const [liked, setLiked] = useState(false);
 
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
@@ -39,6 +42,16 @@ function App() {
           onChange={setEmail}
         />
         <S.EmailText>입력한 이메일: {email}</S.EmailText>
+        <Button onClick={() => setCount((c) => c + 1)}>카운트 증가</Button>
+        <S.CountText>현재 카운트: {count}</S.CountText>
+        <Button
+          variant="icon"
+          ariaLabel="좋아요 토글"
+          pressed={liked}
+          onPressedChange={setLiked}
+        >
+          {liked ? '💙' : '🤍'}
+        </Button>
       </S.Container>
     </>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+import { FaRegThumbsUp, FaThumbsUp } from 'react-icons/fa';
 
 import Button from '@/components/button';
 import HomeTitleBar from '@/components/homeTitleBar';
+import IconButton from '@/components/iconButton';
 import InputTextWithEmail from '@/components/inputTextWithEmail';
 import LoginButton from '@/components/loginButton';
 import LoginTitleBar from '@/components/loginTitleBar';
@@ -17,6 +19,7 @@ function App() {
   const [menuCount, setMenuCount] = useState(0);
   const [count, setCount] = useState(0);
   const [liked, setLiked] = useState(false);
+  const [iconLoading, setIconLoading] = useState(false);
   const [loginLoading, setLoginLoading] = useState(false);
   const [textCount, setTextCount] = useState(0);
   const [textLiked, setTextLiked] = useState(false);
@@ -50,14 +53,26 @@ function App() {
         <S.EmailText>입력한 이메일: {email}</S.EmailText>
         <Button onClick={() => setCount((c) => c + 1)}>카운트 증가</Button>
         <S.CountText>현재 카운트: {count}</S.CountText>
-        <Button
-          variant="icon"
+        <IconButton
           ariaLabel="좋아요 토글"
           pressed={liked}
           onPressedChange={setLiked}
         >
-          {liked ? '💙' : '🤍'}
-        </Button>
+          {liked ? <FaThumbsUp /> : <FaRegThumbsUp />}
+        </IconButton>
+        <IconButton
+          ariaLabel="아이콘 로딩"
+          loading={iconLoading}
+          onClick={() => {
+            setIconLoading(true);
+            setTimeout(() => setIconLoading(false), 1000);
+          }}
+        >
+          <FaThumbsUp />
+        </IconButton>
+        <IconButton ariaLabel="비활성 아이콘" disabled>
+          <FaThumbsUp />
+        </IconButton>
         <LoginButton
           ariaLabel="카카오 로그인"
           loading={loginLoading}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import LoginButton from '@/components/loginButton';
 import LoginTitleBar from '@/components/loginTitleBar';
 import NavigationTab from '@/components/navigationTab';
 import OriginTitleBar from '@/components/originTitleBar';
+import TextButton from '@/components/textButton';
 
 import * as S from './App.styled.ts';
 
@@ -17,6 +18,9 @@ function App() {
   const [count, setCount] = useState(0);
   const [liked, setLiked] = useState(false);
   const [loginLoading, setLoginLoading] = useState(false);
+  const [textCount, setTextCount] = useState(0);
+  const [textLiked, setTextLiked] = useState(false);
+  const [textLoading, setTextLoading] = useState(false);
 
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
@@ -62,6 +66,28 @@ function App() {
             setTimeout(() => setLoginLoading(false), 1000);
           }}
         />
+        <TextButton onClick={() => setTextCount((c) => c + 1)}>
+          텍스트 증가
+        </TextButton>
+        <S.CountText>텍스트 카운트: {textCount}</S.CountText>
+        <TextButton
+          ariaLabel="텍스트 좋아요"
+          pressed={textLiked}
+          onPressedChange={setTextLiked}
+        >
+          {textLiked ? 'ON' : 'OFF'}
+        </TextButton>
+        <TextButton
+          ariaLabel="텍스트 로딩 버튼"
+          loading={textLoading}
+          onClick={() => {
+            setTextLoading(true);
+            setTimeout(() => setTextLoading(false), 1000);
+          }}
+        >
+          로딩
+        </TextButton>
+        <TextButton disabled>비활성 텍스트</TextButton>
       </S.Container>
     </>
   );

--- a/src/components/button/button.styled.ts
+++ b/src/components/button/button.styled.ts
@@ -1,0 +1,155 @@
+import { css, keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'text'
+  | 'icon'
+  | 'round'
+  | 'login';
+export type ButtonSize = 'sm' | 'md' | 'lg';
+
+const variantStyles = {
+  primary: css`
+    background: ${colors.brand.kakaoYellow};
+    color: ${colors.brand.kakaoBrown};
+    &:hover {
+      background: ${colors.brand.kakaoYellowHover};
+    }
+    &:active {
+      background: ${colors.brand.kakaoYellowPressed};
+    }
+  `,
+  secondary: css`
+    background: ${colors.background.fill};
+    color: ${colors.text.default};
+    border: 1px solid ${colors.border.default};
+    &:hover {
+      background: ${colors.gray[100]};
+    }
+    &:active {
+      background: ${colors.gray[200]};
+    }
+  `,
+  text: css`
+    background: transparent;
+    color: ${colors.text.default};
+    padding: 0;
+    &:hover {
+      background: ${colors.background.fill};
+    }
+    &:active {
+      background: ${colors.gray[200]};
+    }
+  `,
+  icon: css`
+    background: transparent;
+    color: ${colors.text.default};
+    padding: ${spacing.spacing2};
+    border-radius: ${spacing.spacing1};
+    &:hover {
+      background: ${colors.background.fill};
+    }
+    &:active {
+      background: ${colors.gray[200]};
+    }
+  `,
+  round: css`
+    background: ${colors.brand.kakaoYellow};
+    color: ${colors.brand.kakaoBrown};
+    border-radius: 50%;
+    padding: ${spacing.spacing3};
+    &:hover {
+      background: ${colors.brand.kakaoYellowHover};
+    }
+    &:active {
+      background: ${colors.brand.kakaoYellowPressed};
+    }
+  `,
+  login: css`
+    background: ${colors.brand.kakaoYellow};
+    color: ${colors.brand.kakaoBrown};
+    ${typography.subtitle1Bold};
+    &:hover {
+      background: ${colors.brand.kakaoYellowHover};
+    }
+    &:active {
+      background: ${colors.brand.kakaoYellowPressed};
+    }
+  `,
+} as const;
+
+const sizeStyles = {
+  sm: css`
+    padding: ${spacing.spacing2} ${spacing.spacing3};
+    ${typography.body2Bold};
+  `,
+  md: css`
+    padding: ${spacing.spacing3} ${spacing.spacing4};
+    ${typography.body1Bold};
+  `,
+  lg: css`
+    padding: ${spacing.spacing4} ${spacing.spacing6};
+    ${typography.title2Bold};
+  `,
+} as const;
+
+export const StyledButton = styled.button<{
+  variant: ButtonVariant;
+  size: ButtonSize;
+}>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+  ${typography.body1Bold};
+
+  ${({ size }) => sizeStyles[size]};
+  ${({ variant }) => variantStyles[variant]};
+
+  &:focus-visible {
+    outline: 2px solid ${colors.status.info};
+    outline-offset: 2px;
+  }
+
+  &[disabled],
+  &[data-loading='true'] {
+    cursor: not-allowed;
+    opacity: 0.6;
+    pointer-events: none;
+  }
+
+  &[disabled]:hover,
+  &[data-loading='true']:hover,
+  &[disabled]:active,
+  &[data-loading='true']:active {
+    background: inherit;
+  }
+
+  &[aria-pressed='true'] {
+    box-shadow: inset 0 0 0 2px ${colors.border.default};
+    filter: saturate(1.05);
+  }
+`;
+
+const spin = keyframes`
+  to {
+    transform: rotate(360deg);
+  }
+`;
+
+export const Spinner = styled.div`
+  width: 1em;
+  height: 1em;
+  border: 2px solid ${colors.background.fill};
+  border-top-color: ${colors.text.sub};
+  border-radius: 50%;
+  animation: ${spin} 0.6s linear infinite;
+`;

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,0 +1,73 @@
+import type {
+  ComponentPropsWithoutRef,
+  MouseEventHandler,
+  ReactNode,
+} from 'react';
+
+import * as S from './button.styled';
+
+export interface ButtonOwnProps {
+  variant?: S.ButtonVariant;
+  size?: S.ButtonSize;
+  loading?: boolean;
+  disabled?: boolean;
+  ariaLabel?: string; // icon 변형이면 필수
+  pressed?: boolean; // 토글 상태
+  onPressedChange?: (v: boolean) => void; // 토글 핸들러(선택)
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  children?: ReactNode;
+}
+
+export type ButtonProps = ButtonOwnProps &
+  Omit<ComponentPropsWithoutRef<'button'>, keyof ButtonOwnProps | 'type'>;
+
+const Button = ({
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  loading = false,
+  ariaLabel,
+  pressed,
+  onPressedChange,
+  onClick,
+  children,
+  ...rest
+}: ButtonProps) => {
+  if (variant === 'icon' && !ariaLabel) {
+    console.warn(
+      '[Button] `icon` variant requires `ariaLabel` for accessibility.',
+    );
+  }
+
+  const isDisabled = disabled || loading;
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (e) => {
+    onClick?.(e);
+    if (!isDisabled && typeof pressed === 'boolean' && onPressedChange) {
+      onPressedChange(!pressed);
+    }
+  };
+
+  return (
+    <S.StyledButton
+      type="button"
+      variant={variant}
+      size={size}
+      disabled={isDisabled}
+      aria-label={ariaLabel}
+      aria-busy={loading || undefined}
+      aria-pressed={typeof pressed === 'boolean' ? pressed : undefined}
+      data-loading={loading ? 'true' : undefined}
+      onClick={handleClick}
+      {...rest}
+    >
+      {loading ? (
+        <S.Spinner role="status" aria-live="polite" aria-label="loading" />
+      ) : (
+        children
+      )}
+    </S.StyledButton>
+  );
+};
+
+export default Button;

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,0 +1,2 @@
+export { default } from './button';
+export * from './button';

--- a/src/components/iconButton/iconButton.styled.ts
+++ b/src/components/iconButton/iconButton.styled.ts
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+
+import Button from '@/components/button';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const StyledIconButton = styled(Button)`
+  ${typography.body1Bold};
+  width: ${spacing.spacing10};
+  height: ${spacing.spacing10};
+  padding: ${spacing.spacing2};
+  color: ${colors.text.default};
+  background: transparent;
+  border-radius: ${spacing.spacing1};
+
+  &:hover {
+    background: ${colors.background.fill};
+  }
+
+  &:active {
+    background: ${colors.gray[200]};
+  }
+
+  svg {
+    width: ${spacing.spacing5};
+    height: ${spacing.spacing5};
+  }
+`;

--- a/src/components/iconButton/iconButton.tsx
+++ b/src/components/iconButton/iconButton.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+import type { ButtonProps } from '@/components/button';
+
+import * as S from './iconButton.styled';
+
+export interface IconButtonProps
+  extends Omit<ButtonProps, 'variant' | 'ariaLabel'> {
+  ariaLabel: string;
+  children?: ReactNode;
+}
+
+const IconButton = ({ ariaLabel, children, ...rest }: IconButtonProps) => {
+  return (
+    <S.StyledIconButton variant="icon" ariaLabel={ariaLabel} {...rest}>
+      {children}
+    </S.StyledIconButton>
+  );
+};
+
+export default IconButton;

--- a/src/components/iconButton/index.ts
+++ b/src/components/iconButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './iconButton';
+export * from './iconButton';

--- a/src/components/loginButton/index.ts
+++ b/src/components/loginButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './loginButton.tsx';
+export type { LoginButtonProps } from './loginButton.tsx';

--- a/src/components/loginButton/loginButton.styled.ts
+++ b/src/components/loginButton/loginButton.styled.ts
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+import Button from '@/components/button';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const StyledLoginButton = styled(Button)`
+  width: 100%;
+  ${typography.subtitle1Bold};
+  padding: ${spacing.spacing3} ${spacing.spacing4};
+  background: ${colors.brand.kakaoYellow};
+  color: ${colors.brand.kakaoBrown};
+
+  &:hover {
+    background: ${colors.brand.kakaoYellowHover};
+  }
+
+  &:active {
+    background: ${colors.brand.kakaoYellowPressed};
+  }
+`;

--- a/src/components/loginButton/loginButton.tsx
+++ b/src/components/loginButton/loginButton.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+import type { ButtonProps } from '@/components/button/button';
+
+import * as S from './loginButton.styled';
+
+export interface LoginButtonProps
+  extends Omit<ButtonProps, 'variant' | 'children'> {
+  children?: ReactNode;
+}
+
+const LoginButton = ({
+  children = '카카오로 시작하기',
+  ...rest
+}: LoginButtonProps) => {
+  return (
+    <S.StyledLoginButton variant="login" {...rest}>
+      {children}
+    </S.StyledLoginButton>
+  );
+};
+
+export default LoginButton;

--- a/src/components/textButton/index.ts
+++ b/src/components/textButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './textButton';
+export * from './textButton';

--- a/src/components/textButton/textButton.styled.ts
+++ b/src/components/textButton/textButton.styled.ts
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+import Button from '@/components/button';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+export const StyledTextButton = styled(Button)`
+  ${typography.body2Bold};
+  padding: ${spacing.spacing2} ${spacing.spacing4};
+  color: ${colors.text.default};
+  background: transparent;
+  border-radius: ${spacing.spacing1};
+
+  &:hover {
+    background: ${colors.background.fill};
+  }
+
+  &:active {
+    background: ${colors.gray[200]};
+  }
+`;

--- a/src/components/textButton/textButton.tsx
+++ b/src/components/textButton/textButton.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+import type { ButtonProps } from '@/components/button/button';
+
+import * as S from './textButton.styled';
+
+export interface TextButtonProps extends Omit<ButtonProps, 'variant'> {
+  children?: ReactNode;
+}
+
+const TextButton = ({ children, ...rest }: TextButtonProps) => {
+  return (
+    <S.StyledTextButton variant="text" {...rest}>
+      {children}
+    </S.StyledTextButton>
+  );
+};
+
+export default TextButton;

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -20,4 +20,17 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: 'profile' }));
     expect(screen.getByText('Profile 클릭 횟수: 1')).toBeInTheDocument();
   });
+
+  it('increments count when button is clicked', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: '카운트 증가' }));
+    expect(screen.getByText('현재 카운트: 1')).toBeInTheDocument();
+  });
+
+  it('toggles like button', () => {
+    render(<App />);
+    const btn = screen.getByRole('button', { name: '좋아요 토글' });
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
 });

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -33,4 +33,10 @@ describe('App', () => {
     fireEvent.click(btn);
     expect(btn).toHaveAttribute('aria-pressed', 'true');
   });
+
+  it('increments text count when TextButton is clicked', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: '텍스트 증가' }));
+    expect(screen.getByText('텍스트 카운트: 1')).toBeInTheDocument();
+  });
 });

--- a/src/tests/button.test.tsx
+++ b/src/tests/button.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import Button from '@/components/button';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button>버튼</Button>);
+    expect(screen.getByRole('button', { name: '버튼' })).toBeInTheDocument();
+  });
+
+  it('handles click event', () => {
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>클릭</Button>);
+    fireEvent.click(screen.getByRole('button', { name: '클릭' }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<Button disabled>비활성</Button>);
+    expect(screen.getByRole('button', { name: '비활성' })).toBeDisabled();
+  });
+
+  it('passes through arbitrary aria attributes', () => {
+    render(
+      <Button aria-label="more" aria-describedby="tip">
+        텍스트
+      </Button>,
+    );
+    expect(screen.getByRole('button', { name: 'more' })).toHaveAttribute(
+      'aria-describedby',
+      'tip',
+    );
+  });
+
+  it('toggles pressed state', () => {
+    const handleChange = vi.fn();
+    render(
+      <Button
+        variant="icon"
+        ariaLabel="좋아요"
+        pressed={false}
+        onPressedChange={handleChange}
+      >
+        🤍
+      </Button>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '좋아요' }));
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('shows spinner and sets aria-busy when loading', () => {
+    render(<Button loading ariaLabel="로딩 버튼" />);
+    const btn = screen.getByRole('button', { name: '로딩 버튼' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+  });
+
+  it('applies primary variant styles', () => {
+    render(<Button variant="primary">스타일</Button>);
+    expect(screen.getByRole('button', { name: '스타일' })).toHaveStyle(
+      `background: ${colors.brand.kakaoYellow}`,
+    );
+  });
+
+  it('applies lg size padding', () => {
+    render(<Button size="lg">큰 버튼</Button>);
+    expect(screen.getByRole('button', { name: '큰 버튼' })).toHaveStyle(
+      `padding: ${spacing.spacing4} ${spacing.spacing6}`,
+    );
+  });
+});

--- a/src/tests/iconButton.test.tsx
+++ b/src/tests/iconButton.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FaThumbsUp } from 'react-icons/fa';
+import { describe, it, expect, vi } from 'vitest';
+
+import IconButton from '@/components/iconButton';
+import { spacing } from '@/theme/spacing';
+
+describe('IconButton', () => {
+  it('renders icon children', () => {
+    render(
+      <IconButton ariaLabel="like">
+        <FaThumbsUp />
+      </IconButton>,
+    );
+    expect(screen.getByRole('button', { name: 'like' })).toBeInTheDocument();
+  });
+
+  it('handles pressed state change', () => {
+    const handleChange = vi.fn();
+    render(
+      <IconButton
+        ariaLabel="toggle"
+        pressed={false}
+        onPressedChange={handleChange}
+      >
+        <FaThumbsUp />
+      </IconButton>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('shows loading spinner and aria-busy', () => {
+    render(
+      <IconButton ariaLabel="loading" loading>
+        <FaThumbsUp />
+      </IconButton>,
+    );
+    const btn = screen.getByRole('button', { name: 'loading' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+  });
+
+  it('applies spacing-based size', () => {
+    render(
+      <IconButton ariaLabel="size-test">
+        <FaThumbsUp />
+      </IconButton>,
+    );
+    expect(screen.getByRole('button', { name: 'size-test' })).toHaveStyle(
+      `width: ${spacing.spacing10}`,
+    );
+  });
+});

--- a/src/tests/loginButton.test.tsx
+++ b/src/tests/loginButton.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import LoginButton from '@/components/loginButton';
+import { colors } from '@/theme/color';
+
+describe('LoginButton', () => {
+  it('renders default text', () => {
+    render(<LoginButton />);
+    expect(
+      screen.getByRole('button', { name: '카카오로 시작하기' }),
+    ).toBeInTheDocument();
+  });
+
+  it('allows overriding children', () => {
+    render(<LoginButton>다른 텍스트</LoginButton>);
+    expect(
+      screen.getByRole('button', { name: '다른 텍스트' }),
+    ).toBeInTheDocument();
+  });
+
+  it('handles click', () => {
+    const handleClick = vi.fn();
+    render(<LoginButton onClick={handleClick} />);
+    fireEvent.click(screen.getByRole('button', { name: '카카오로 시작하기' }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<LoginButton disabled />);
+    expect(
+      screen.getByRole('button', { name: '카카오로 시작하기' }),
+    ).toBeDisabled();
+  });
+
+  it('shows spinner and sets aria-busy when loading', () => {
+    render(<LoginButton loading ariaLabel="로그인" />);
+    const btn = screen.getByRole('button', { name: '로그인' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+  });
+
+  it('toggles pressed state', () => {
+    const handleChange = vi.fn();
+    render(
+      <LoginButton
+        ariaLabel="로그인 토글"
+        pressed={false}
+        onPressedChange={handleChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '로그인 토글' }));
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('applies login variant styles', () => {
+    render(<LoginButton>로그인</LoginButton>);
+    expect(screen.getByRole('button', { name: '로그인' })).toHaveStyle(
+      `background: ${colors.brand.kakaoYellow}`,
+    );
+  });
+});

--- a/src/tests/textButton.test.tsx
+++ b/src/tests/textButton.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import TextButton from '@/components/textButton';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+
+describe('TextButton', () => {
+  it('renders children', () => {
+    render(<TextButton>텍스트</TextButton>);
+    expect(screen.getByRole('button', { name: '텍스트' })).toBeInTheDocument();
+  });
+
+  it('handles click event', () => {
+    const handleClick = vi.fn();
+    render(<TextButton onClick={handleClick}>클릭</TextButton>);
+    fireEvent.click(screen.getByRole('button', { name: '클릭' }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('applies default text styles', () => {
+    render(<TextButton>스타일</TextButton>);
+    expect(screen.getByRole('button', { name: '스타일' })).toHaveStyle(
+      `background: transparent; padding: ${spacing.spacing2} ${spacing.spacing4}; color: ${colors.text.default}`,
+    );
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<TextButton disabled>비활성</TextButton>);
+    expect(screen.getByRole('button', { name: '비활성' })).toBeDisabled();
+  });
+
+  it('shows spinner and sets aria-busy when loading', () => {
+    render(<TextButton loading ariaLabel="로딩" />);
+    const btn = screen.getByRole('button', { name: '로딩' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+  });
+
+  it('toggles pressed state', () => {
+    const handle = vi.fn();
+    render(
+      <TextButton ariaLabel="토글" pressed={false} onPressedChange={handle} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '토글' }));
+    expect(handle).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
## 📄 변경 사항 요약

- Button을 기반으로 ariaLabel을 필수로 받는 IconButton을 추가하고, 텍스트·간격·색상 토큰을 활용한 스타일을 분리
- App 예시에 react-icons 아이콘을 사용한 토글·로딩·비활성 아이콘 버튼을 구성

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #71 

---

## 📸 스크린샷 또는 동영상 

https://github.com/user-attachments/assets/2d5abfaf-ff5c-4b3e-8b0c-d17feee5f7df

---

## 🧪 테스트 방법 

(1) renders icon children
아이콘(FaThumbsUp)을 children으로 넣었을 때 버튼이 정상 렌더링 되는지 확인.
ariaLabel="like"를 통해 스크린 리더에서 접근 가능한 버튼인지 확인.

(2) handles pressed state change
pressed={false} 상태에서 클릭 → true로 바뀌는지 확인.
토글 버튼처럼 작동하는지 검증 (onPressedChange(true) 호출 확인).

(3) shows loading spinner and aria-busy
loading 상태일 때:
접근성 속성 aria-busy="true"가 버튼에 붙는지 확인.
로딩 스피너(role="status", 이름 "loading")가 DOM에 나타나는지 확인.

(4) applies spacing-based size
IconButton이 **spacing 시스템을 기반으로 한 크기(width)**를 올바르게 적용하는지 확인.
즉, 아이콘 버튼은 일반 텍스트 버튼처럼 padding이 아니라, 테마에 정의된 spacing 값으로 크기를 관리한다는 걸 검증하는 테스트.
---
