### PR TITLE
[KAN-44] Feature/kan 44 round button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import LoginButton from '@/components/loginButton';
 import LoginTitleBar from '@/components/loginTitleBar';
 import NavigationTab from '@/components/navigationTab';
 import OriginTitleBar from '@/components/originTitleBar';
+import RoundButton from '@/components/roundButton';
 import TextButton from '@/components/textButton';
 
 import * as S from './App.styled.ts';
@@ -24,6 +25,8 @@ function App() {
   const [textCount, setTextCount] = useState(0);
   const [textLiked, setTextLiked] = useState(false);
   const [textLoading, setTextLoading] = useState(false);
+  const [roundLiked, setRoundLiked] = useState(false);
+  const [roundCount, setRoundCount] = useState(0);
 
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
@@ -103,6 +106,17 @@ function App() {
           로딩
         </TextButton>
         <TextButton disabled>비활성 텍스트</TextButton>
+        <RoundButton
+          ariaLabel="라운드 좋아요"
+          pressed={roundLiked}
+          onPressedChange={setRoundLiked}
+        >
+          {roundLiked ? <FaThumbsUp /> : <FaRegThumbsUp />}
+        </RoundButton>
+        <RoundButton size="lg" onClick={() => setRoundCount((c) => c + 1)}>
+          GO
+        </RoundButton>
+        <S.CountText>라운드 버튼 클릭 횟수: {roundCount}</S.CountText>
       </S.Container>
     </>
   );

--- a/src/components/roundButton/index.ts
+++ b/src/components/roundButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './roundButton';
+export type { RoundButtonProps } from './roundButton';

--- a/src/components/roundButton/roundButton.styled.ts
+++ b/src/components/roundButton/roundButton.styled.ts
@@ -1,0 +1,45 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import Button from '@/components/button';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+import { typography } from '@/theme/typography';
+
+const sizeStyles = {
+  md: css`
+    width: ${spacing.spacing12};
+    height: ${spacing.spacing12};
+    ${typography.title2Bold};
+    svg {
+      width: ${spacing.spacing6};
+      height: ${spacing.spacing6};
+    }
+  `,
+  lg: css`
+    width: ${spacing.spacing16};
+    height: ${spacing.spacing16};
+    ${typography.title1Bold};
+    svg {
+      width: ${spacing.spacing8};
+      height: ${spacing.spacing8};
+    }
+  `,
+} as const;
+
+export const StyledRoundButton = styled(Button)<{ size: 'md' | 'lg' }>`
+  padding: 0;
+  border-radius: 50%;
+  background: ${colors.brand.kakaoYellow};
+  color: ${colors.brand.kakaoBrown};
+
+  ${({ size }) => sizeStyles[size]};
+
+  &:hover {
+    background: ${colors.brand.kakaoYellowHover};
+  }
+
+  &:active {
+    background: ${colors.brand.kakaoYellowPressed};
+  }
+`;

--- a/src/components/roundButton/roundButton.tsx
+++ b/src/components/roundButton/roundButton.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from 'react';
+
+import type { ButtonProps } from '@/components/button';
+
+import * as S from './roundButton.styled';
+
+export interface RoundButtonProps
+  extends Omit<ButtonProps, 'variant' | 'size'> {
+  size?: 'md' | 'lg';
+  children?: ReactNode;
+}
+
+const RoundButton = ({ size = 'md', children, ...rest }: RoundButtonProps) => {
+  return (
+    <S.StyledRoundButton variant="round" size={size} {...rest}>
+      {children}
+    </S.StyledRoundButton>
+  );
+};
+
+export default RoundButton;

--- a/src/tests/roundButton.test.tsx
+++ b/src/tests/roundButton.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FaThumbsUp } from 'react-icons/fa';
+import { describe, it, expect, vi } from 'vitest';
+
+import RoundButton from '@/components/roundButton';
+import { spacing } from '@/theme/spacing';
+
+describe('RoundButton', () => {
+  it('renders icon child', () => {
+    render(
+      <RoundButton ariaLabel="like">
+        <FaThumbsUp />
+      </RoundButton>,
+    );
+    expect(screen.getByRole('button', { name: 'like' })).toBeInTheDocument();
+  });
+
+  it('handles pressed state change', () => {
+    const handleChange = vi.fn();
+    render(
+      <RoundButton
+        ariaLabel="toggle"
+        pressed={false}
+        onPressedChange={handleChange}
+      >
+        <FaThumbsUp />
+      </RoundButton>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('shows loading spinner and aria-busy', () => {
+    render(
+      <RoundButton ariaLabel="loading" loading>
+        <FaThumbsUp />
+      </RoundButton>,
+    );
+    const btn = screen.getByRole('button', { name: 'loading' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+  });
+
+  it('applies md and lg size styles', () => {
+    const { rerender } = render(<RoundButton ariaLabel="size-md" size="md" />);
+    const mdButton = screen.getByRole('button', { name: 'size-md' });
+    expect(mdButton).toHaveStyle(`width: ${spacing.spacing12}`);
+    expect(mdButton).toHaveStyle(`height: ${spacing.spacing12}`);
+
+    rerender(<RoundButton ariaLabel="size-lg" size="lg" />);
+    const lgButton = screen.getByRole('button', { name: 'size-lg' });
+    expect(lgButton).toHaveStyle(`width: ${spacing.spacing16}`);
+    expect(lgButton).toHaveStyle(`height: ${spacing.spacing16}`);
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<RoundButton ariaLabel="disabled" disabled />);
+    expect(screen.getByRole('button', { name: 'disabled' })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## 📄 변경 사항 요약

- oundButton 컴포넌트를 추가하여 기본 변형을 round로 지정하고 md·lg 크기에 아이콘·텍스트 자식을 지원하도록 구현
- 디자인 토큰(typography, spacing, color)을 활용한 스타일을 별도 파일로 분리해 hover·active 상태까지 세심하게 다룸.

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #72 
---

## 📸 스크린샷 또는 동영상
https://github.com/user-attachments/assets/314cccfd-b921-465f-a774-371e01b09afa

---

## 🧪 테스트 방법

(1) renders icon child
버튼에 아이콘이 children으로 들어갔을 때 정상적으로 렌더링되는지 확인.
ariaLabel="like" 속성을 통해 접근성(스크린 리더) 지원 여부도 검증.

(2) handles pressed state change
버튼이 토글 가능 상태인지 확인.
처음에 pressed={false} → 클릭 시 true로 바뀌고 onPressedChange(true) 콜백이 실행되는지 검증.

(3) shows loading spinner and aria-busy
로딩 상태일 때:
aria-busy="true" 속성이 버튼에 붙는지
로딩 스피너(role="status", 이름 "loading")가 보이는지 확인.

(4) applies md and lg size styles
size prop이 "md"일 때 → 가로/세로가 spacing.spacing12 값인지 확인.
size prop이 "lg"일 때 → 가로/세로가 spacing.spacing16 값인지 확인.
즉, 버튼이 정사각형 형태이고 크기 값이 테마의 spacing 기준에 맞는지 테스트.

(5) is disabled when disabled prop is set
disabled 속성을 주면 버튼이 비활성화되는지 확인.
---
