### PR TITLE
[KAN-39] refactor(titlebar): 타이틀바 전체에 버튼 객체 주입

### DIFF
--- a/src/components/homeTitleBar/homeTitleBar.styled.ts
+++ b/src/components/homeTitleBar/homeTitleBar.styled.ts
@@ -16,15 +16,6 @@ export const Wrapper = styled(TitleBar)`
   }
 `;
 
-export const IconButton = styled.button`
-  border: none;
-  background: none;
-  padding: ${spacing.spacing2};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-`;
 export const ProfileIcon = styled(CgProfile)`
   width: ${spacing.spacing6};
   height: ${spacing.spacing6};

--- a/src/components/homeTitleBar/homeTitleBar.tsx
+++ b/src/components/homeTitleBar/homeTitleBar.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import IconButton from '@/components/iconButton';
+
 import * as S from './homeTitleBar.styled';
 
 interface HomeTitleBarProps {
@@ -12,9 +14,9 @@ const HomeTitleBar = ({ title, onMenu }: HomeTitleBarProps) => {
     <S.Wrapper
       title={title}
       rightSlot={
-        <S.IconButton aria-label="profile" onClick={onMenu}>
-          <S.ProfileIcon />
-        </S.IconButton>
+        <IconButton ariaLabel="profile" onClick={onMenu}>
+          <S.ProfileIcon aria-hidden />
+        </IconButton>
       }
     />
   );

--- a/src/components/originTitleBar/originTitleBar.styled.ts
+++ b/src/components/originTitleBar/originTitleBar.styled.ts
@@ -1,24 +1,16 @@
 import styled from '@emotion/styled';
+import { MdArrowBack } from 'react-icons/md';
 
 import TitleBar from '@/components/titleBar';
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
-import { typography } from '@/theme/typography';
 
 export const Wrapper = styled(TitleBar)`
   background-color: ${colors.background.default};
 `;
 
-export const BackButton = styled.button`
-  width: ${spacing.spacing14};
-  height: ${spacing.spacing14};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  padding: 0;
+export const BackIcon = styled(MdArrowBack)`
+  width: ${spacing.spacing5};
+  height: ${spacing.spacing5};
   color: ${colors.text.default};
-  ${typography.title1Bold};
-  cursor: pointer;
 `;

--- a/src/components/originTitleBar/originTitleBar.tsx
+++ b/src/components/originTitleBar/originTitleBar.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import IconButton from '@/components/iconButton';
+
 import * as S from './originTitleBar.styled';
 
 interface OriginTitleBarProps {
@@ -13,9 +15,9 @@ const OriginTitleBar = ({ title, onBack, className }: OriginTitleBarProps) => {
     <S.Wrapper
       className={className}
       leftSlot={
-        <S.BackButton onClick={onBack} aria-label="뒤로 가기">
-          ←
-        </S.BackButton>
+        <IconButton ariaLabel="뒤로 가기" onClick={onBack}>
+          <S.BackIcon aria-hidden />
+        </IconButton>
       }
       title={title}
     />

--- a/src/components/titleBar/titleBar.styled.ts
+++ b/src/components/titleBar/titleBar.styled.ts
@@ -20,6 +20,9 @@ export const Slot = styled.div`
 
 export const Title = styled.div`
   flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   color: ${colors.text.default};
   ${typography.title1Bold};

--- a/src/components/titleBar/titleBar.tsx
+++ b/src/components/titleBar/titleBar.tsx
@@ -4,7 +4,7 @@ import * as S from './titleBar.styled';
 
 interface TitleBarProps {
   leftSlot?: React.ReactNode;
-  title?: string;
+  title?: React.ReactNode;
   rightSlot?: React.ReactNode;
   className?: string;
 }

--- a/src/tests/homeTitleBar.test.tsx
+++ b/src/tests/homeTitleBar.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 
 import HomeTitleBar from '@/components/homeTitleBar';
 import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
 
 describe('HomeTitleBar', () => {
@@ -36,9 +37,9 @@ describe('HomeTitleBar', () => {
     expect(title).toHaveStyle(
       `font-weight: ${typography.title1Bold.fontWeight}`,
     );
-    const profileIcon = screen.getByRole('button', {
-      name: 'profile',
-    }).firstChild;
+    const profileButton = screen.getByRole('button', { name: 'profile' });
+    expect(profileButton).toHaveStyle(`width: ${spacing.spacing10}`);
+    const profileIcon = profileButton.firstChild as HTMLElement;
     expect(profileIcon).toHaveStyle(`color: ${colors.text.default}`);
   });
 });

--- a/src/tests/originTitleBar.test.tsx
+++ b/src/tests/originTitleBar.test.tsx
@@ -23,8 +23,11 @@ describe('OriginTitleBar', () => {
     render(<OriginTitleBar title="Origin" onBack={() => {}} />);
 
     const backButton = screen.getByLabelText('뒤로 가기');
-    expect(backButton).toHaveStyle(`width: ${spacing.spacing14}`);
+    expect(backButton).toHaveStyle(`width: ${spacing.spacing10}`);
     expect(backButton).toHaveStyle(`color: ${colors.text.default}`);
+
+    const icon = backButton.firstChild as HTMLElement;
+    expect(icon).toHaveStyle(`color: ${colors.text.default}`);
 
     const title = screen.getByText('Origin');
     expect(title).toHaveStyle(


### PR DESCRIPTION
## 📄 변경 사항 요약

- TitleBar가 타이틀을 ReactNode로 받도록 확장하고 중앙 정렬을 flex 기반으로 개선하여 높이·정렬 변화 없이 슬롯을 구성
- 타이틀바 아이콘을 MdArrowBack으로 교체
- HomeTitleBar와 OriginTitleBar에서 IconButton 내부에 react-icons 기반 아이콘을 주입하도록 리팩터링
- 타이틀바 홈:아이콘 버튼 주입으로 변경 기존 아이콘 버튼 스타일 제거
- 타이블바 오리진:새로운 리엑트 아이콘 주입 , 기존 백 드로우 텍스트 제거

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #65 

---

## 📸 스크린샷 또는 동영상 (선택)

https://github.com/user-attachments/assets/37fd5865-92f6-419f-981b-fd3db1875d3e

---
