### PR TITLE
[KAN-49] Feature/kan 49 round rectangle button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import LoginTitleBar from '@/components/loginTitleBar';
 import NavigationTab from '@/components/navigationTab';
 import OriginTitleBar from '@/components/originTitleBar';
 import RoundButton from '@/components/roundButton';
+import RoundedRectangleButton from '@/components/roundedRectangleButton';
 import TextButton from '@/components/textButton';
 
 import * as S from './App.styled.ts';
@@ -27,6 +28,7 @@ function App() {
   const [textLoading, setTextLoading] = useState(false);
   const [roundLiked, setRoundLiked] = useState(false);
   const [roundCount, setRoundCount] = useState(0);
+  const [rrCount, setRrCount] = useState(0);
 
   const tabs = [
     { label: 'Home', content: <div>Home Content</div> },
@@ -117,6 +119,10 @@ function App() {
           GO
         </RoundButton>
         <S.CountText>라운드 버튼 클릭 횟수: {roundCount}</S.CountText>
+        <RoundedRectangleButton onClick={() => setRrCount((c) => c + 1)}>
+          라운드 직사각 버튼
+        </RoundedRectangleButton>
+        <S.CountText>라운드 직사각 버튼 클릭 횟수: {rrCount}</S.CountText>
       </S.Container>
     </>
   );

--- a/src/components/homeTitleBar/homeTitleBar.styled.ts
+++ b/src/components/homeTitleBar/homeTitleBar.styled.ts
@@ -16,15 +16,6 @@ export const Wrapper = styled(TitleBar)`
   }
 `;
 
-export const IconButton = styled.button`
-  border: none;
-  background: none;
-  padding: ${spacing.spacing2};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-`;
 export const ProfileIcon = styled(CgProfile)`
   width: ${spacing.spacing6};
   height: ${spacing.spacing6};

--- a/src/components/homeTitleBar/homeTitleBar.tsx
+++ b/src/components/homeTitleBar/homeTitleBar.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import IconButton from '@/components/iconButton';
+
 import * as S from './homeTitleBar.styled';
 
 interface HomeTitleBarProps {
@@ -12,9 +14,9 @@ const HomeTitleBar = ({ title, onMenu }: HomeTitleBarProps) => {
     <S.Wrapper
       title={title}
       rightSlot={
-        <S.IconButton aria-label="profile" onClick={onMenu}>
-          <S.ProfileIcon />
-        </S.IconButton>
+        <IconButton ariaLabel="profile" onClick={onMenu}>
+          <S.ProfileIcon aria-hidden />
+        </IconButton>
       }
     />
   );

--- a/src/components/originTitleBar/originTitleBar.styled.ts
+++ b/src/components/originTitleBar/originTitleBar.styled.ts
@@ -1,24 +1,16 @@
 import styled from '@emotion/styled';
+import { MdArrowBack } from 'react-icons/md';
 
 import TitleBar from '@/components/titleBar';
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
-import { typography } from '@/theme/typography';
 
 export const Wrapper = styled(TitleBar)`
   background-color: ${colors.background.default};
 `;
 
-export const BackButton = styled.button`
-  width: ${spacing.spacing14};
-  height: ${spacing.spacing14};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: none;
-  border: none;
-  padding: 0;
+export const BackIcon = styled(MdArrowBack)`
+  width: ${spacing.spacing5};
+  height: ${spacing.spacing5};
   color: ${colors.text.default};
-  ${typography.title1Bold};
-  cursor: pointer;
 `;

--- a/src/components/originTitleBar/originTitleBar.tsx
+++ b/src/components/originTitleBar/originTitleBar.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import IconButton from '@/components/iconButton';
+
 import * as S from './originTitleBar.styled';
 
 interface OriginTitleBarProps {
@@ -13,9 +15,9 @@ const OriginTitleBar = ({ title, onBack, className }: OriginTitleBarProps) => {
     <S.Wrapper
       className={className}
       leftSlot={
-        <S.BackButton onClick={onBack} aria-label="뒤로 가기">
-          ←
-        </S.BackButton>
+        <IconButton ariaLabel="뒤로 가기" onClick={onBack}>
+          <S.BackIcon aria-hidden />
+        </IconButton>
       }
       title={title}
     />

--- a/src/components/roundedRectangleButton/index.ts
+++ b/src/components/roundedRectangleButton/index.ts
@@ -1,0 +1,2 @@
+export { default } from './roundedRectangleButton';
+export * from './roundedRectangleButton';

--- a/src/components/roundedRectangleButton/roundedRectangleButton.styled.ts
+++ b/src/components/roundedRectangleButton/roundedRectangleButton.styled.ts
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import Button from '@/components/button';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+
+export interface RoundedRectangleColors {
+  background?: string;
+  color?: string;
+  hover?: string;
+  active?: string;
+}
+
+const defaultColors = {
+  background: colors.blue[700],
+  color: colors.gray[0],
+  hover: colors.blue[800],
+  active: colors.blue[900],
+};
+
+export const StyledRoundedRectangleButton = styled(Button, {
+  shouldForwardProp: (prop) => prop !== 'colorSet',
+})<{
+  colorSet?: RoundedRectangleColors;
+}>`
+  border-radius: ${spacing.spacing2};
+  ${({ colorSet }) => {
+    const c = { ...defaultColors, ...colorSet };
+    return css`
+      background: ${c.background};
+      color: ${c.color};
+      border: 1px solid ${c.background};
+      &:hover {
+        background: ${c.hover};
+      }
+      &:active {
+        background: ${c.active};
+      }
+    `;
+  }}
+`;

--- a/src/components/roundedRectangleButton/roundedRectangleButton.tsx
+++ b/src/components/roundedRectangleButton/roundedRectangleButton.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+
+import type { ButtonProps } from '@/components/button';
+
+import * as S from './roundedRectangleButton.styled';
+
+export interface RoundedRectangleButtonProps
+  extends Omit<ButtonProps, 'variant'> {
+  colorSet?: S.RoundedRectangleColors;
+  children?: ReactNode;
+}
+
+const RoundedRectangleButton = ({
+  colorSet,
+  children,
+  ...rest
+}: RoundedRectangleButtonProps) => {
+  return (
+    <S.StyledRoundedRectangleButton
+      variant="secondary"
+      colorSet={colorSet}
+      {...rest}
+    >
+      {children}
+    </S.StyledRoundedRectangleButton>
+  );
+};
+
+export default RoundedRectangleButton;

--- a/src/components/titleBar/titleBar.styled.ts
+++ b/src/components/titleBar/titleBar.styled.ts
@@ -20,6 +20,9 @@ export const Slot = styled.div`
 
 export const Title = styled.div`
   flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   color: ${colors.text.default};
   ${typography.title1Bold};

--- a/src/components/titleBar/titleBar.tsx
+++ b/src/components/titleBar/titleBar.tsx
@@ -4,7 +4,7 @@ import * as S from './titleBar.styled';
 
 interface TitleBarProps {
   leftSlot?: React.ReactNode;
-  title?: string;
+  title?: React.ReactNode;
   rightSlot?: React.ReactNode;
   className?: string;
 }

--- a/src/tests/homeTitleBar.test.tsx
+++ b/src/tests/homeTitleBar.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 
 import HomeTitleBar from '@/components/homeTitleBar';
 import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
 
 describe('HomeTitleBar', () => {
@@ -36,9 +37,9 @@ describe('HomeTitleBar', () => {
     expect(title).toHaveStyle(
       `font-weight: ${typography.title1Bold.fontWeight}`,
     );
-    const profileIcon = screen.getByRole('button', {
-      name: 'profile',
-    }).firstChild;
+    const profileButton = screen.getByRole('button', { name: 'profile' });
+    expect(profileButton).toHaveStyle(`width: ${spacing.spacing10}`);
+    const profileIcon = profileButton.firstChild as HTMLElement;
     expect(profileIcon).toHaveStyle(`color: ${colors.text.default}`);
   });
 });

--- a/src/tests/originTitleBar.test.tsx
+++ b/src/tests/originTitleBar.test.tsx
@@ -23,8 +23,11 @@ describe('OriginTitleBar', () => {
     render(<OriginTitleBar title="Origin" onBack={() => {}} />);
 
     const backButton = screen.getByLabelText('뒤로 가기');
-    expect(backButton).toHaveStyle(`width: ${spacing.spacing14}`);
+    expect(backButton).toHaveStyle(`width: ${spacing.spacing10}`);
     expect(backButton).toHaveStyle(`color: ${colors.text.default}`);
+
+    const icon = backButton.firstChild as HTMLElement;
+    expect(icon).toHaveStyle(`color: ${colors.text.default}`);
 
     const title = screen.getByText('Origin');
     expect(title).toHaveStyle(

--- a/src/tests/roundedRectangleButton.test.tsx
+++ b/src/tests/roundedRectangleButton.test.tsx
@@ -1,0 +1,42 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import Button from '@/components/button';
+import { colors } from '@/theme/color';
+import { spacing } from '@/theme/spacing';
+
+export interface RoundedRectangleColors {
+  background?: string;
+  color?: string;
+  hover?: string;
+  active?: string;
+}
+
+const defaultColors = {
+  background: colors.blue[700],
+  color: colors.gray[0],
+  hover: colors.blue[800],
+  active: colors.blue[900],
+};
+
+export const StyledRoundedRectangleButton = styled(Button, {
+  shouldForwardProp: (prop) => prop !== 'colorSet',
+})<{
+  colorSet?: RoundedRectangleColors;
+}>`
+  border-radius: ${spacing.spacing2};
+  ${({ colorSet }) => {
+    const c = { ...defaultColors, ...colorSet };
+    return css`
+      background: ${c.background};
+      color: ${c.color};
+      border: 1px solid ${c.background};
+      &:hover {
+        background: ${c.hover};
+      }
+      &:active {
+        background: ${c.active};
+      }
+    `;
+  }}
+`;

--- a/src/tests/roundedRectangleButton.test.tsx
+++ b/src/tests/roundedRectangleButton.test.tsx
@@ -1,42 +1,70 @@
-import { css } from '@emotion/react';
-import styled from '@emotion/styled';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
-import Button from '@/components/button';
+import RoundedRectangleButton from '@/components/roundedRectangleButton';
 import { colors } from '@/theme/color';
-import { spacing } from '@/theme/spacing';
 
-export interface RoundedRectangleColors {
-  background?: string;
-  color?: string;
-  hover?: string;
-  active?: string;
-}
+describe('RoundedRectangleButton', () => {
+  it('renders children text', () => {
+    render(<RoundedRectangleButton>버튼</RoundedRectangleButton>);
+    expect(screen.getByRole('button', { name: '버튼' })).toBeInTheDocument();
+  });
 
-const defaultColors = {
-  background: colors.blue[700],
-  color: colors.gray[0],
-  hover: colors.blue[800],
-  active: colors.blue[900],
-};
+  it('applies default blue styles', () => {
+    render(<RoundedRectangleButton>스타일</RoundedRectangleButton>);
+    const button = screen.getByRole('button', { name: '스타일' });
+    expect(button).toHaveStyle(`background: ${colors.blue[700]}`);
+    expect(button).toHaveStyle(`color: ${colors.gray[0]}`);
+    expect(button).toHaveStyle(`border: 1px solid ${colors.blue[700]}`);
+  });
 
-export const StyledRoundedRectangleButton = styled(Button, {
-  shouldForwardProp: (prop) => prop !== 'colorSet',
-})<{
-  colorSet?: RoundedRectangleColors;
-}>`
-  border-radius: ${spacing.spacing2};
-  ${({ colorSet }) => {
-    const c = { ...defaultColors, ...colorSet };
-    return css`
-      background: ${c.background};
-      color: ${c.color};
-      border: 1px solid ${c.background};
-      &:hover {
-        background: ${c.hover};
-      }
-      &:active {
-        background: ${c.active};
-      }
-    `;
-  }}
-`;
+  it('allows color override via props', () => {
+    const custom = {
+      background: colors.red[700],
+      color: colors.gray[0],
+      hover: colors.red[800],
+      active: colors.red[900],
+    };
+    render(
+      <RoundedRectangleButton colorSet={custom}>커스텀</RoundedRectangleButton>,
+    );
+    const button = screen.getByRole('button', { name: '커스텀' });
+    expect(button).toHaveStyle(`background: ${colors.red[700]}`);
+  });
+
+  it('handles click events', () => {
+    const handleClick = vi.fn();
+    render(
+      <RoundedRectangleButton onClick={handleClick}>
+        클릭
+      </RoundedRectangleButton>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '클릭' }));
+    expect(handleClick).toHaveBeenCalled();
+  });
+
+  it('shows spinner and aria-busy when loading', () => {
+    render(<RoundedRectangleButton loading ariaLabel="로딩" />);
+    const btn = screen.getByRole('button', { name: '로딩' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+  });
+
+  it('is disabled when disabled prop is set', () => {
+    render(<RoundedRectangleButton disabled>비활성</RoundedRectangleButton>);
+    expect(screen.getByRole('button', { name: '비활성' })).toBeDisabled();
+  });
+
+  it('toggles pressed state', () => {
+    const handle = vi.fn();
+    render(
+      <RoundedRectangleButton
+        ariaLabel="토글"
+        pressed={false}
+        onPressedChange={handle}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '토글' }));
+    expect(handle).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
## 📄 변경 사항 요약

- RoundedRectangleButton 컴포넌트를 추가하여 variant="secondary" 기반의 둥근 직사각형 버튼을 구현하고, 파란색 계열을 기본값으로 두면서 props로 색상 오버라이드를 지원
- App.tsx에 새로운 버튼을 배치하고 클릭 횟수 표시로 테스트 가능한 화면을 구성

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #82 

---

## 📸 스크린샷 또는 동영상 

https://github.com/user-attachments/assets/ea56a0f0-ae99-41d9-979b-fef60e98660a


---

## 🧪 테스트 방법 

1. 텍스트 렌더링
children으로 넘긴 텍스트가 버튼의 접근 가능한 이름으로 잘 노출되는지 확인.

2.기본 스타일(블루 세트) 적용
기본 배경/글자색/테두리가 테마 값에 맞게 적용되는지 확인.

3.색상 오버라이드
colorSet prop으로 기본 팔레트를 덮어쓸 수 있는지 확인(최소 배경색 검증).

4.클릭 이벤트
클릭 시 핸들러 호출 여부 확인.
팁: 실제 사용자 상호작용에 가깝게 하려면 @testing-library/user-event의 userEvent.click 사용을 권장.

5.로딩 상태(+ 접근성)
로딩 중 aria-busy="true" 노출, 스피너가 role="status"로 접근 가능하게 표시되는지 확인.

6.비활성화
disabled prop 동작 검증.

7.토글(pressed) 상태
토글형 버튼 UX: 클릭 시 onPressedChange(true)가 호출되는지 확인.

---
