### PR TITLE
[KAN-57] fix(tsconfig): 중복되던 경로 옵션 제거 및 확장 설정

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2022",
@@ -21,11 +22,7 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
-    "baseUrl": "src",
-    "paths": {
-      "@/*": ["*"]
-    }
+    "noUncheckedSideEffectImports": true
   },
   "include": ["src"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2023",


### PR DESCRIPTION
## 📄 변경 사항 요약

- tsconfig.app.json에서 중복되던 경로 관련 옵션을 제거하고 루트 설정을 확장하도록 구성해 공통 설정을 재사용하게 함.
- tsconfig.node.json 역시 루트 설정을 상속받도록 변경해 Node 타겟에서도 동일한 경로 별칭을 활용하도록 정리

---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #96 

---
