### PR TITLE
[KAN-56] fix(inputtextwithemail): 제어 컴포넌트로 전환

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,7 @@ function App() {
         <p>Back 클릭 횟수: {backCount}</p>
         <NavigationTab tabs={tabs} />
         <InputTextWithEmail
+          value={email}
           helperText="학교 이메일을 입력해주세요."
           onChange={setEmail}
         />

--- a/src/components/InputTextWithEmail/inputTextWithEmail.tsx
+++ b/src/components/InputTextWithEmail/inputTextWithEmail.tsx
@@ -1,15 +1,21 @@
-import { useState, type ChangeEvent } from 'react';
+import { type ChangeEvent } from 'react';
 
 import * as S from './inputTextWithEmail.styled';
 
-interface InputTextWithEmailProps {
-  value?: string;
+export interface InputTextWithEmailProps {
+  value: string;
   defaultDomain?: string;
   helperText?: string;
-  onChange?: (value: string) => void;
+  onChange: (value: string) => void;
 }
 
 const DEFAULT_DOMAIN = 'pusan.ac.kr';
+
+const splitEmail = (email: string): [string, string] => {
+  const [local = '', ...rest] = email.split('@');
+  const domain = rest.length > 0 ? rest.join('@') : '';
+  return [local, domain];
+};
 
 const InputTextWithEmail = ({
   value,
@@ -17,40 +23,24 @@ const InputTextWithEmail = ({
   helperText,
   onChange,
 }: InputTextWithEmailProps) => {
-  const [localPart, setLocalPart] = useState(() => {
-    const [local] = value ? value.split('@') : [''];
-    return local;
-  });
-
-  const initialDomain = value?.split('@')[1];
-  const isCustomInitial = initialDomain && initialDomain !== defaultDomain;
-  const [isCustomDomainSelected, setIsCustomDomainSelected] =
-    useState(!!isCustomInitial);
-  const [domain, setDomain] = useState(
-    isCustomInitial ? (initialDomain ?? '') : defaultDomain,
-  );
+  const [localPart, domainPart] = splitEmail(value);
+  const isCustomDomainSelected = domainPart !== defaultDomain;
 
   const handleLocalChange = (e: ChangeEvent<HTMLInputElement>) => {
     const local = e.target.value;
-    setLocalPart(local);
-    onChange?.(`${local}@${domain}`);
+    onChange(`${local}@${domainPart}`);
   };
 
   const handleDomainSelectChange = (e: ChangeEvent<HTMLSelectElement>) => {
     if (e.target.value === 'other') {
-      setIsCustomDomainSelected(true);
-      setDomain('');
-      onChange?.(`${localPart}@`);
-    } else {
-      setIsCustomDomainSelected(false);
-      setDomain(defaultDomain);
-      onChange?.(`${localPart}@${defaultDomain}`);
+      onChange(`${localPart}@`);
+      return;
     }
+    onChange(`${localPart}@${defaultDomain}`);
   };
 
   const handleDomainInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setDomain(e.target.value);
-    onChange?.(`${localPart}@${e.target.value}`);
+    onChange(`${localPart}@${e.target.value}`);
   };
 
   return (
@@ -59,20 +49,20 @@ const InputTextWithEmail = ({
         <S.LocalInput
           value={localPart}
           onChange={handleLocalChange}
-          aria-label="email local part"
+          aria-label="이메일 아이디 입력"
         />
         <S.AtSign>@</S.AtSign>
         {isCustomDomainSelected ? (
           <S.DomainInput
-            value={domain}
+            value={domainPart}
             onChange={handleDomainInputChange}
-            aria-label="email domain input"
+            aria-label="이메일 도메인 입력"
           />
         ) : (
           <S.DomainSelect
-            value={defaultDomain}
+            value={isCustomDomainSelected ? 'other' : defaultDomain}
             onChange={handleDomainSelectChange}
-            aria-label="email domain select"
+            aria-label="이메일 도메인 선택"
           >
             <option value={defaultDomain}>{defaultDomain}</option>
             <option value="other">직접입력</option>

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -4,9 +4,9 @@ import { describe, it, expect } from 'vitest';
 import App from '@/App';
 
 describe('App', () => {
-  it('renders email input component', () => {
+  it('이메일 입력 컴포넌트를 렌더링한다', () => {
     render(<App />);
-    expect(screen.getByLabelText(/email local part/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('이메일 아이디 입력')).toBeInTheDocument();
   });
 
   it('renders navigation tabs and switches content', () => {

--- a/src/tests/component/others/inputTextWithEmail.test.tsx
+++ b/src/tests/component/others/inputTextWithEmail.test.tsx
@@ -1,44 +1,81 @@
 import { render, screen, fireEvent } from '@testing-library/react';
+import { useState } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 
 import InputTextWithEmail from '@/components/inputTextWithEmail';
+const DEFAULT_DOMAIN = 'pusan.ac.kr';
 
-describe('InputTextWithEmail', () => {
-  it('renders default domain', () => {
-    render(<InputTextWithEmail />);
-    const select = screen.getByLabelText('email domain select');
+const ControlledInputTextWithEmail = ({
+  initialValue = `@${DEFAULT_DOMAIN}`,
+  onChange = () => {},
+  helperText,
+}: {
+  initialValue?: string;
+  onChange?: (value: string) => void;
+  helperText?: string;
+}) => {
+  const [email, setEmail] = useState(initialValue);
+
+  const handleChange = (nextValue: string) => {
+    setEmail(nextValue);
+    onChange(nextValue);
+  };
+
+  return (
+    <InputTextWithEmail
+      value={email}
+      onChange={handleChange}
+      helperText={helperText}
+    />
+  );
+};
+
+describe('InputTextWithEmail 컴포넌트', () => {
+  it('기본 도메인을 렌더링한다', () => {
+    render(<ControlledInputTextWithEmail />);
+    const select = screen.getByLabelText('이메일 도메인 선택');
     expect(select).toHaveValue('pusan.ac.kr');
     expect(
       screen.getByRole('option', { name: '직접입력' }),
     ).toBeInTheDocument();
   });
 
-  it('calls onChange with default domain', () => {
+  it('기본 도메인으로 onChange를 호출한다', () => {
     const handleChange = vi.fn();
-    render(<InputTextWithEmail onChange={handleChange} />);
-    fireEvent.change(screen.getByLabelText('email local part'), {
+    render(
+      <ControlledInputTextWithEmail
+        onChange={handleChange}
+        initialValue={`@${DEFAULT_DOMAIN}`}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('이메일 아이디 입력'), {
       target: { value: 'test' },
     });
     expect(handleChange).toHaveBeenLastCalledWith('test@pusan.ac.kr');
   });
 
-  it('allows custom domain input', () => {
+  it('사용자가 도메인을 직접 입력할 수 있다', () => {
     const handleChange = vi.fn();
-    render(<InputTextWithEmail onChange={handleChange} />);
-    fireEvent.change(screen.getByLabelText('email domain select'), {
+    render(
+      <ControlledInputTextWithEmail
+        onChange={handleChange}
+        initialValue={`@${DEFAULT_DOMAIN}`}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('이메일 도메인 선택'), {
       target: { value: 'other' },
     });
-    fireEvent.change(screen.getByLabelText('email domain input'), {
+    fireEvent.change(screen.getByLabelText('이메일 도메인 입력'), {
       target: { value: 'gmail.com' },
     });
-    fireEvent.change(screen.getByLabelText('email local part'), {
+    fireEvent.change(screen.getByLabelText('이메일 아이디 입력'), {
       target: { value: 'test' },
     });
     expect(handleChange).toHaveBeenLastCalledWith('test@gmail.com');
   });
 
-  it('shows helper text', () => {
-    render(<InputTextWithEmail helperText="이메일을 입력하세요" />);
+  it('헬퍼 텍스트를 표시한다', () => {
+    render(<ControlledInputTextWithEmail helperText="이메일을 입력하세요" />);
     expect(screen.getByText('이메일을 입력하세요')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 📄 변경 사항 요약

- InputTextWithEmail 컴포넌트를 필수 value·onChange을 받는 제어 컴포넌트로 전환하고, 이메일 분리 유틸을 추가해 도메인 선택 로직을 단순화
- App에서 이메일 상태를 전달하도록 컴포넌트 사용 코드를 업데이트해 새로운 제어 방식과 동기화
- 테스트에 제어용 래퍼를 도입해 변경된 컴포넌트 계약을 검증하도록 수정
- InputTextWithEmail 컴포넌트의 aria-label을 한국어로 변경해 접근성 텍스트와 실제 UI 레이블을 일치
- 관련 컴포넌트 테스트를 한국어 설명과 라벨 검사로 업데이트하여 새 접근성 문구를 검증
- 앱 통합 테스트에서도 한국어 라벨을 사용하도록 수정해 전체 흐름이 일관되게 동작하는지 확인
---

## ✅ PR 체크리스트

- [ O ] PR 제목은 변경 사항을 명확히 나타내나요?
- [ O ] `develop` 브랜치와 충돌이 없나요?
- [ O ] 로컬에서 충분히 테스트했나요?
- [ O ] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #95 

---
