### PR TITLE
Feature/kan 61 inputtextwithemail validation

### DIFF
--- a/src/components/InputTextWithEmail/inputTextWithEmail.tsx
+++ b/src/components/InputTextWithEmail/inputTextWithEmail.tsx
@@ -11,10 +11,28 @@ export interface InputTextWithEmailProps {
 
 const DEFAULT_DOMAIN = 'pusan.ac.kr';
 
+const EMAIL_PATTERN = /^([^@]*)@([^@]*)$/;
+const LOCAL_PART_PATTERN = /^[a-zA-Z0-9._%+-]+$/;
+const DOMAIN_PART_PATTERN = /^(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+$/;
+
+const isValidLocalPart = (value: string) =>
+  value === '' || LOCAL_PART_PATTERN.test(value);
+
+const isValidDomainPart = (value: string) =>
+  value === '' || DOMAIN_PART_PATTERN.test(value);
+
 const splitEmail = (email: string): [string, string] => {
-  const [local = '', ...rest] = email.split('@');
-  const domain = rest.length > 0 ? rest.join('@') : '';
-  return [local, domain];
+  const match = EMAIL_PATTERN.exec(email.trim());
+
+  if (!match) {
+    return ['', ''];
+  }
+
+  const [, localPart, domainPart] = match;
+  const sanitizedLocalPart = isValidLocalPart(localPart) ? localPart : '';
+  const sanitizedDomainPart = isValidDomainPart(domainPart) ? domainPart : '';
+
+  return [sanitizedLocalPart, sanitizedDomainPart];
 };
 
 const InputTextWithEmail = ({

--- a/src/tests/component/others/inputTextWithEmail.test.tsx
+++ b/src/tests/component/others/inputTextWithEmail.test.tsx
@@ -78,4 +78,11 @@ describe('InputTextWithEmail 컴포넌트', () => {
     render(<ControlledInputTextWithEmail helperText="이메일을 입력하세요" />);
     expect(screen.getByText('이메일을 입력하세요')).toBeInTheDocument();
   });
+
+  it('잘못된 이메일 형식이 주어지면 입력값을 초기화한다', () => {
+    render(<ControlledInputTextWithEmail initialValue="invalid@@domain" />);
+
+    expect(screen.getByLabelText('이메일 아이디 입력')).toHaveValue('');
+    expect(screen.getByLabelText('이메일 도메인 입력')).toHaveValue('');
+  });
 });


### PR DESCRIPTION
## 📄 변경 사항 요약

- 이메일 파싱 로직을 정규식 기반으로 재구성하고 로컬/도메인 유효성을 검증하도록 개선
- 잘못된 이메일 형식이 전달될 때 입력을 초기화하는 동작을 검증하는 테스트를 추가

---

## ✅ PR 체크리스트

- [x] PR 제목은 변경 사항을 명확히 나타내나요?
- [x] `develop` 브랜치와 충돌이 없나요?
- [x] 로컬에서 충분히 테스트했나요?
- [x] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #104 

---
