### PR TITLE
[KAN-63] Refactor/kan 63 testcode to korean

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import Button, {
 } from '@/components/button';
 import IconButton, { ToggleIconButton } from '@/components/button/iconButton';
 import LoginButton from '@/components/button/loginButton';
-import InputTextWithEmail from '@/components/inputTextWithEmail';
+import InputTextWithEmail from '@/components/InputTextWithEmail';
 import MatchCard from '@/components/matchCard';
 import NavigationTab from '@/components/navigationTab';
 import HomeTitleBar from '@/components/titleBar/homeTitleBar/index.ts';
@@ -35,9 +35,9 @@ function App() {
   const [rrCount, setRrCount] = useState(0);
 
   const tabs = [
-    { label: 'Home', content: <div>Home Content</div> },
-    { label: 'Search', content: <div>Search Content</div> },
-    { label: 'Profile', content: <div>Profile Content</div> },
+    { label: '홈', content: <div>홈 콘텐츠</div> },
+    { label: '검색', content: <div>검색 콘텐츠</div> },
+    { label: '프로필', content: <div>프로필 콘텐츠</div> },
   ];
 
   return (
@@ -52,8 +52,8 @@ function App() {
       />
       <LoginTitleBar />
       <S.Container>
-        <p>Profile 클릭 횟수: {menuCount}</p>
-        <p>Back 클릭 횟수: {backCount}</p>
+        <p>프로필 클릭 횟수: {menuCount}</p>
+        <p>뒤로 가기 클릭 횟수: {backCount}</p>
         <NavigationTab tabs={tabs} />
         <InputTextWithEmail
           value={email}

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -56,7 +56,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...rest}
       >
         {loading ? (
-          <S.Spinner role="status" aria-live="polite" aria-label="loading" />
+          <S.Spinner role="status" aria-live="polite" aria-label="로딩 중" />
         ) : (
           children
         )}

--- a/src/components/titleBar/homeTitleBar/homeTitleBar.tsx
+++ b/src/components/titleBar/homeTitleBar/homeTitleBar.tsx
@@ -12,7 +12,7 @@ const HomeTitleBar = ({ title, onMenu }: HomeTitleBarProps) => {
     <S.Wrapper
       title={title}
       rightSlot={
-        <IconButton ariaLabel="profile" onClick={onMenu}>
+        <IconButton ariaLabel="프로필" onClick={onMenu}>
           <S.ProfileIcon aria-hidden />
         </IconButton>
       }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,5 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
 export const handlers = [
-  http.get('/api/greeting', () => HttpResponse.json({ greeting: 'hello' })),
+  http.get('/api/greeting', () =>
+    HttpResponse.json({ greeting: '안녕하세요' }),
+  ),
 ];

--- a/src/tests/App.test.tsx
+++ b/src/tests/App.test.tsx
@@ -3,38 +3,38 @@ import { describe, it, expect } from 'vitest';
 
 import App from '@/App';
 
-describe('App', () => {
+describe('App 컴포넌트', () => {
   it('이메일 입력 컴포넌트를 렌더링한다', () => {
     render(<App />);
     expect(screen.getByLabelText('이메일 아이디 입력')).toBeInTheDocument();
   });
 
-  it('renders navigation tabs and switches content', () => {
+  it('내비게이션 탭을 렌더링하고 콘텐츠를 전환한다', () => {
     render(<App />);
-    expect(screen.getByRole('tab', { name: 'Home' })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole('tab', { name: 'Search' }));
-    expect(screen.getByText('Search Content')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: '홈' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: '검색' }));
+    expect(screen.getByText('검색 콘텐츠')).toBeInTheDocument();
   });
   it('프로필 버튼 클릭 시 카운트가 증가한다', () => {
     render(<App />);
-    fireEvent.click(screen.getByRole('button', { name: 'profile' }));
-    expect(screen.getByText('Profile 클릭 횟수: 1')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '프로필' }));
+    expect(screen.getByText('프로필 클릭 횟수: 1')).toBeInTheDocument();
   });
 
-  it('increments count when button is clicked', () => {
+  it('버튼을 클릭하면 카운트를 증가시킨다', () => {
     render(<App />);
     fireEvent.click(screen.getByRole('button', { name: '카운트 증가' }));
     expect(screen.getByText('현재 카운트: 1')).toBeInTheDocument();
   });
 
-  it('toggles like button', () => {
+  it('좋아요 버튼을 토글한다', () => {
     render(<App />);
     const btn = screen.getByRole('button', { name: '좋아요 토글' });
     fireEvent.click(btn);
     expect(btn).toHaveAttribute('aria-pressed', 'true');
   });
 
-  it('increments text count when TextButton is clicked', () => {
+  it('텍스트 버튼 클릭 시 카운트를 증가시킨다', () => {
     render(<App />);
     fireEvent.click(screen.getByRole('button', { name: '텍스트 증가' }));
     expect(screen.getByText('텍스트 카운트: 1')).toBeInTheDocument();

--- a/src/tests/api/apiClient.test.ts
+++ b/src/tests/api/apiClient.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import { fetchGreeting } from '@/api/apiClient';
 
-describe('fetchGreeting', () => {
-  it('returns mocked greeting', async () => {
+describe('fetchGreeting 함수', () => {
+  it('모킹된 인사말을 반환한다', async () => {
     const data = await fetchGreeting();
-    expect(data.greeting).toBe('hello');
+    expect(data.greeting).toBe('안녕하세요');
   });
 });

--- a/src/tests/component/button/button.test.tsx
+++ b/src/tests/component/button/button.test.tsx
@@ -5,51 +5,51 @@ import Button, { ToggleButton } from '@/components/button';
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 
-describe('Button', () => {
-  it('renders children', () => {
+describe('Button 컴포넌트', () => {
+  it('자식 요소를 렌더링한다', () => {
     render(<Button>버튼</Button>);
     expect(screen.getByRole('button', { name: '버튼' })).toBeInTheDocument();
   });
 
-  it('handles click event', () => {
+  it('클릭 이벤트를 처리한다', () => {
     const handleClick = vi.fn();
     render(<Button onClick={handleClick}>클릭</Button>);
     fireEvent.click(screen.getByRole('button', { name: '클릭' }));
     expect(handleClick).toHaveBeenCalled();
   });
 
-  it('is disabled when disabled prop is set', () => {
+  it('disabled 속성이 설정되면 비활성화된다', () => {
     render(<Button disabled>비활성</Button>);
     expect(screen.getByRole('button', { name: '비활성' })).toBeDisabled();
   });
 
-  it('passes through arbitrary aria attributes', () => {
+  it('임의의 aria 속성을 전달한다', () => {
     render(
-      <Button aria-label="more" aria-describedby="tip">
+      <Button aria-label="추가" aria-describedby="도움말">
         텍스트
       </Button>,
     );
-    expect(screen.getByRole('button', { name: 'more' })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: '추가' })).toHaveAttribute(
       'aria-describedby',
-      'tip',
+      '도움말',
     );
   });
 
-  it('shows spinner and sets aria-busy when loading', () => {
+  it('로딩 중 스피너를 표시하고 aria-busy를 설정한다', () => {
     render(<Button loading ariaLabel="로딩 버튼" />);
     const btn = screen.getByRole('button', { name: '로딩 버튼' });
     expect(btn).toHaveAttribute('aria-busy', 'true');
-    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: '로딩 중' })).toBeInTheDocument();
   });
 
-  it('applies primary variant styles', () => {
+  it('프라이머리 변형 스타일을 적용한다', () => {
     render(<Button variant="primary">스타일</Button>);
     expect(screen.getByRole('button', { name: '스타일' })).toHaveStyle(
       `background: ${colors.brand.kakaoYellow}`,
     );
   });
 
-  it('applies lg size padding', () => {
+  it('라지 크기 패딩을 적용한다', () => {
     render(<Button size="lg">큰 버튼</Button>);
     expect(screen.getByRole('button', { name: '큰 버튼' })).toHaveStyle(
       `padding: ${spacing.spacing4} ${spacing.spacing6}`,
@@ -57,8 +57,8 @@ describe('Button', () => {
   });
 });
 
-describe('ToggleButton', () => {
-  it('toggles pressed state', () => {
+describe('ToggleButton 컴포넌트', () => {
+  it('pressed 상태를 전환한다', () => {
     const handleChange = vi.fn();
     render(
       <ToggleButton

--- a/src/tests/component/button/iconButton.test.tsx
+++ b/src/tests/component/button/iconButton.test.tsx
@@ -5,49 +5,49 @@ import { describe, it, expect, vi } from 'vitest';
 import IconButton, { ToggleIconButton } from '@/components/button/iconButton';
 import { spacing } from '@/theme/spacing';
 
-describe('IconButton', () => {
-  it('renders icon children', () => {
+describe('IconButton 컴포넌트', () => {
+  it('아이콘 자식 요소를 렌더링한다', () => {
     render(
-      <IconButton ariaLabel="like">
+      <IconButton ariaLabel="좋아요">
         <FaThumbsUp />
       </IconButton>,
     );
-    expect(screen.getByRole('button', { name: 'like' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '좋아요' })).toBeInTheDocument();
   });
 
-  it('handles pressed state change', () => {
+  it('pressed 상태 변경을 처리한다', () => {
     const handleChange = vi.fn();
     render(
       <ToggleIconButton
-        ariaLabel="toggle"
+        ariaLabel="토글"
         pressed={false}
         onPressedChange={handleChange}
       >
         <FaThumbsUp />
       </ToggleIconButton>,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
+    fireEvent.click(screen.getByRole('button', { name: '토글' }));
     expect(handleChange).toHaveBeenCalledWith(true);
   });
 
-  it('shows loading spinner and aria-busy', () => {
+  it('로딩 스피너를 표시하고 aria-busy를 설정한다', () => {
     render(
-      <IconButton ariaLabel="loading" loading>
+      <IconButton ariaLabel="로딩" loading>
         <FaThumbsUp />
       </IconButton>,
     );
-    const btn = screen.getByRole('button', { name: 'loading' });
+    const btn = screen.getByRole('button', { name: '로딩' });
     expect(btn).toHaveAttribute('aria-busy', 'true');
-    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: '로딩 중' })).toBeInTheDocument();
   });
 
-  it('applies spacing-based size', () => {
+  it('spacing 기반 크기를 적용한다', () => {
     render(
-      <IconButton ariaLabel="size-test">
+      <IconButton ariaLabel="크기 테스트">
         <FaThumbsUp />
       </IconButton>,
     );
-    expect(screen.getByRole('button', { name: 'size-test' })).toHaveStyle(
+    expect(screen.getByRole('button', { name: '크기 테스트' })).toHaveStyle(
       `width: ${spacing.spacing10}`,
     );
   });

--- a/src/tests/component/button/loginButton.test.tsx
+++ b/src/tests/component/button/loginButton.test.tsx
@@ -6,43 +6,43 @@ import LoginButton, {
 } from '@/components/button/loginButton';
 import { colors } from '@/theme/color';
 
-describe('LoginButton', () => {
-  it('renders default text', () => {
+describe('LoginButton 컴포넌트', () => {
+  it('기본 텍스트를 렌더링한다', () => {
     render(<LoginButton />);
     expect(
       screen.getByRole('button', { name: '카카오로 시작하기' }),
     ).toBeInTheDocument();
   });
 
-  it('allows overriding children', () => {
+  it('자식 요소를 덮어쓸 수 있다', () => {
     render(<LoginButton>다른 텍스트</LoginButton>);
     expect(
       screen.getByRole('button', { name: '다른 텍스트' }),
     ).toBeInTheDocument();
   });
 
-  it('handles click', () => {
+  it('클릭을 처리한다', () => {
     const handleClick = vi.fn();
     render(<LoginButton onClick={handleClick} />);
     fireEvent.click(screen.getByRole('button', { name: '카카오로 시작하기' }));
     expect(handleClick).toHaveBeenCalled();
   });
 
-  it('is disabled when disabled prop is set', () => {
+  it('disabled 속성이 설정되면 비활성화된다', () => {
     render(<LoginButton disabled />);
     expect(
       screen.getByRole('button', { name: '카카오로 시작하기' }),
     ).toBeDisabled();
   });
 
-  it('shows spinner and sets aria-busy when loading', () => {
+  it('로딩 중 스피너를 표시하고 aria-busy를 설정한다', () => {
     render(<LoginButton loading ariaLabel="로그인" />);
     const btn = screen.getByRole('button', { name: '로그인' });
     expect(btn).toHaveAttribute('aria-busy', 'true');
-    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: '로딩 중' })).toBeInTheDocument();
   });
 
-  it('toggles pressed state', () => {
+  it('pressed 상태를 전환한다', () => {
     const handleChange = vi.fn();
     render(
       <ToggleLoginButton
@@ -55,7 +55,7 @@ describe('LoginButton', () => {
     expect(handleChange).toHaveBeenCalledWith(true);
   });
 
-  it('applies login variant styles', () => {
+  it('login 변형 스타일을 적용한다', () => {
     render(<LoginButton>로그인</LoginButton>);
     expect(screen.getByRole('button', { name: '로그인' })).toHaveStyle(
       `background: ${colors.brand.kakaoYellow}`,

--- a/src/tests/component/button/roundButton.test.tsx
+++ b/src/tests/component/button/roundButton.test.tsx
@@ -5,56 +5,56 @@ import { describe, it, expect, vi } from 'vitest';
 import { RoundButton, ToggleRoundButton } from '@/components/button';
 import { spacing } from '@/theme/spacing';
 
-describe('RoundButton', () => {
-  it('renders icon child', () => {
+describe('RoundButton 컴포넌트', () => {
+  it('아이콘 자식 요소를 렌더링한다', () => {
     render(
-      <RoundButton ariaLabel="like">
+      <RoundButton ariaLabel="좋아요">
         <FaThumbsUp />
       </RoundButton>,
     );
-    expect(screen.getByRole('button', { name: 'like' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '좋아요' })).toBeInTheDocument();
   });
 
-  it('handles pressed state change', () => {
+  it('pressed 상태 변경을 처리한다', () => {
     const handleChange = vi.fn();
     render(
       <ToggleRoundButton
-        ariaLabel="toggle"
+        ariaLabel="토글"
         pressed={false}
         onPressedChange={handleChange}
       >
         <FaThumbsUp />
       </ToggleRoundButton>,
     );
-    fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
+    fireEvent.click(screen.getByRole('button', { name: '토글' }));
     expect(handleChange).toHaveBeenCalledWith(true);
   });
 
-  it('shows loading spinner and aria-busy', () => {
+  it('로딩 스피너를 표시하고 aria-busy를 설정한다', () => {
     render(
-      <RoundButton ariaLabel="loading" loading>
+      <RoundButton ariaLabel="로딩" loading>
         <FaThumbsUp />
       </RoundButton>,
     );
-    const btn = screen.getByRole('button', { name: 'loading' });
+    const btn = screen.getByRole('button', { name: '로딩' });
     expect(btn).toHaveAttribute('aria-busy', 'true');
-    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: '로딩 중' })).toBeInTheDocument();
   });
 
-  it('applies md and lg size styles', () => {
-    const { rerender } = render(<RoundButton ariaLabel="size-md" size="md" />);
-    const mdButton = screen.getByRole('button', { name: 'size-md' });
+  it('md와 lg 크기 스타일을 적용한다', () => {
+    const { rerender } = render(<RoundButton ariaLabel="md 크기" size="md" />);
+    const mdButton = screen.getByRole('button', { name: 'md 크기' });
     expect(mdButton).toHaveStyle(`width: ${spacing.spacing12}`);
     expect(mdButton).toHaveStyle(`height: ${spacing.spacing12}`);
 
-    rerender(<RoundButton ariaLabel="size-lg" size="lg" />);
-    const lgButton = screen.getByRole('button', { name: 'size-lg' });
+    rerender(<RoundButton ariaLabel="lg 크기" size="lg" />);
+    const lgButton = screen.getByRole('button', { name: 'lg 크기' });
     expect(lgButton).toHaveStyle(`width: ${spacing.spacing16}`);
     expect(lgButton).toHaveStyle(`height: ${spacing.spacing16}`);
   });
 
-  it('is disabled when disabled prop is set', () => {
-    render(<RoundButton ariaLabel="disabled" disabled />);
-    expect(screen.getByRole('button', { name: 'disabled' })).toBeDisabled();
+  it('disabled 속성이 설정되면 비활성화된다', () => {
+    render(<RoundButton ariaLabel="비활성" disabled />);
+    expect(screen.getByRole('button', { name: '비활성' })).toBeDisabled();
   });
 });

--- a/src/tests/component/button/roundedRectangleButton.test.tsx
+++ b/src/tests/component/button/roundedRectangleButton.test.tsx
@@ -7,13 +7,13 @@ import {
 } from '@/components/button';
 import { colors } from '@/theme/color';
 
-describe('RoundedRectangleButton', () => {
-  it('renders children text', () => {
+describe('RoundedRectangleButton 컴포넌트', () => {
+  it('자식 텍스트를 렌더링한다', () => {
     render(<RoundedRectangleButton>버튼</RoundedRectangleButton>);
     expect(screen.getByRole('button', { name: '버튼' })).toBeInTheDocument();
   });
 
-  it('applies default blue styles', () => {
+  it('기본 파란색 스타일을 적용한다', () => {
     render(<RoundedRectangleButton>스타일</RoundedRectangleButton>);
     const button = screen.getByRole('button', { name: '스타일' });
     expect(button).toHaveStyle(`background: ${colors.blue[700]}`);
@@ -21,7 +21,7 @@ describe('RoundedRectangleButton', () => {
     expect(button).toHaveStyle(`border: 1px solid ${colors.blue[700]}`);
   });
 
-  it('allows color override via props', () => {
+  it('props로 색상을 덮어쓴다', () => {
     const custom = {
       background: colors.red[700],
       color: colors.gray[0],
@@ -35,7 +35,7 @@ describe('RoundedRectangleButton', () => {
     expect(button).toHaveStyle(`background: ${colors.red[700]}`);
   });
 
-  it('handles click events', () => {
+  it('클릭 이벤트를 처리한다', () => {
     const handleClick = vi.fn();
     render(
       <RoundedRectangleButton onClick={handleClick}>
@@ -46,19 +46,19 @@ describe('RoundedRectangleButton', () => {
     expect(handleClick).toHaveBeenCalled();
   });
 
-  it('shows spinner and aria-busy when loading', () => {
+  it('로딩 중 스피너를 표시하고 aria-busy를 설정한다', () => {
     render(<RoundedRectangleButton loading ariaLabel="로딩" />);
     const btn = screen.getByRole('button', { name: '로딩' });
     expect(btn).toHaveAttribute('aria-busy', 'true');
-    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: '로딩 중' })).toBeInTheDocument();
   });
 
-  it('is disabled when disabled prop is set', () => {
+  it('disabled 속성이 설정되면 비활성화된다', () => {
     render(<RoundedRectangleButton disabled>비활성</RoundedRectangleButton>);
     expect(screen.getByRole('button', { name: '비활성' })).toBeDisabled();
   });
 
-  it('toggles pressed state', () => {
+  it('pressed 상태를 전환한다', () => {
     const handle = vi.fn();
     render(
       <ToggleRoundedRectangleButton

--- a/src/tests/component/button/textButton.test.tsx
+++ b/src/tests/component/button/textButton.test.tsx
@@ -5,39 +5,39 @@ import { TextButton, ToggleTextButton } from '@/components/button';
 import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 
-describe('TextButton', () => {
-  it('renders children', () => {
+describe('TextButton 컴포넌트', () => {
+  it('자식 요소를 렌더링한다', () => {
     render(<TextButton>텍스트</TextButton>);
     expect(screen.getByRole('button', { name: '텍스트' })).toBeInTheDocument();
   });
 
-  it('handles click event', () => {
+  it('클릭 이벤트를 처리한다', () => {
     const handleClick = vi.fn();
     render(<TextButton onClick={handleClick}>클릭</TextButton>);
     fireEvent.click(screen.getByRole('button', { name: '클릭' }));
     expect(handleClick).toHaveBeenCalled();
   });
 
-  it('applies default text styles', () => {
+  it('기본 텍스트 스타일을 적용한다', () => {
     render(<TextButton>스타일</TextButton>);
     expect(screen.getByRole('button', { name: '스타일' })).toHaveStyle(
       `background: transparent; padding: ${spacing.spacing2} ${spacing.spacing4}; color: ${colors.text.default}`,
     );
   });
 
-  it('is disabled when disabled prop is set', () => {
+  it('disabled 속성이 설정되면 비활성화된다', () => {
     render(<TextButton disabled>비활성</TextButton>);
     expect(screen.getByRole('button', { name: '비활성' })).toBeDisabled();
   });
 
-  it('shows spinner and sets aria-busy when loading', () => {
+  it('로딩 중 스피너를 표시하고 aria-busy를 설정한다', () => {
     render(<TextButton loading ariaLabel="로딩" />);
     const btn = screen.getByRole('button', { name: '로딩' });
     expect(btn).toHaveAttribute('aria-busy', 'true');
-    expect(screen.getByRole('status', { name: 'loading' })).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: '로딩 중' })).toBeInTheDocument();
   });
 
-  it('toggles pressed state', () => {
+  it('pressed 상태를 전환한다', () => {
     const handle = vi.fn();
     render(
       <ToggleTextButton

--- a/src/tests/component/matchCard/matchCard.test.tsx
+++ b/src/tests/component/matchCard/matchCard.test.tsx
@@ -9,7 +9,7 @@ const renderWithTheme = (ui: React.ReactElement) => {
   return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
 };
 
-describe('MatchCard', () => {
+describe('MatchCard 컴포넌트', () => {
   const defaultProps = {
     title: '부산대 넥서스 E동',
     time: '8/16 18:00 ~ 22:00',

--- a/src/tests/component/others/inputTextWithEmail.test.tsx
+++ b/src/tests/component/others/inputTextWithEmail.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { useState } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 
-import InputTextWithEmail from '@/components/inputTextWithEmail';
+import InputTextWithEmail from '@/components/InputTextWithEmail';
 const DEFAULT_DOMAIN = 'pusan.ac.kr';
 
 const ControlledInputTextWithEmail = ({

--- a/src/tests/component/others/navigationTab.test.tsx
+++ b/src/tests/component/others/navigationTab.test.tsx
@@ -4,30 +4,30 @@ import { describe, it, expect } from 'vitest';
 import NavigationTab from '@/components/navigationTab';
 import { colors } from '@/theme/color';
 
-describe('NavigationTab', () => {
+describe('NavigationTab 컴포넌트', () => {
   const tabs = [
-    { label: 'Home', content: <div>Home Content</div> },
-    { label: 'Search', content: <div>Search Content</div> },
-    { label: 'Profile', content: <div>Profile Content</div> },
+    { label: '홈', content: <div>홈 콘텐츠</div> },
+    { label: '검색', content: <div>검색 콘텐츠</div> },
+    { label: '프로필', content: <div>프로필 콘텐츠</div> },
   ];
 
-  it('renders first tab content by default', () => {
+  it('첫 번째 탭 콘텐츠를 기본으로 렌더링한다', () => {
     render(<NavigationTab tabs={tabs} />);
-    expect(screen.getByText('Home Content')).toBeInTheDocument();
+    expect(screen.getByText('홈 콘텐츠')).toBeInTheDocument();
   });
 
-  it('changes content when a different tab is clicked', () => {
+  it('다른 탭을 클릭하면 콘텐츠가 변경된다', () => {
     render(<NavigationTab tabs={tabs} />);
-    fireEvent.click(screen.getByRole('tab', { name: 'Search' }));
-    expect(screen.getByText('Search Content')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('tab', { name: '검색' }));
+    expect(screen.getByText('검색 콘텐츠')).toBeInTheDocument();
   });
 
-  it('highlights only the selected tab', () => {
+  it('선택된 탭만 강조 표시한다', () => {
     render(<NavigationTab tabs={tabs} />);
-    const searchTab = screen.getByRole('tab', { name: 'Search' });
+    const searchTab = screen.getByRole('tab', { name: '검색' });
     fireEvent.click(searchTab);
     expect(searchTab).toHaveStyle(`color: ${colors.text.default}`);
-    const homeTab = screen.getByRole('tab', { name: 'Home' });
+    const homeTab = screen.getByRole('tab', { name: '홈' });
     expect(homeTab).toHaveStyle(`color: ${colors.text.sub}`);
   });
 });

--- a/src/tests/component/titleBar/homeTitleBar.test.tsx
+++ b/src/tests/component/titleBar/homeTitleBar.test.tsx
@@ -6,7 +6,7 @@ import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
 
-describe('HomeTitleBar', () => {
+describe('HomeTitleBar 컴포넌트', () => {
   it('제목을 렌더링한다', () => {
     render(<HomeTitleBar title="홈" onMenu={() => {}} />);
     expect(screen.getByText('홈')).toBeInTheDocument();
@@ -14,20 +14,20 @@ describe('HomeTitleBar', () => {
 
   it('좌측 아이콘 버튼이 존재하지 않는다', () => {
     render(<HomeTitleBar title="홈" onMenu={() => {}} />);
-    expect(screen.queryByRole('button', { name: 'menu' })).toBeNull();
+    expect(screen.queryByRole('button', { name: '메뉴' })).toBeNull();
   });
 
   it('우측 프로필 아이콘이 렌더링된다', () => {
     render(<HomeTitleBar title="홈" onMenu={() => {}} />);
     expect(
-      screen.getByRole('button', { name: 'profile' }).firstChild,
+      screen.getByRole('button', { name: '프로필' }).firstChild,
     ).toBeInTheDocument();
   });
 
   it('우측 프로필 버튼 클릭 시 핸들러가 호출된다', () => {
     const handleMenu = vi.fn();
     render(<HomeTitleBar title="홈" onMenu={handleMenu} />);
-    fireEvent.click(screen.getByRole('button', { name: 'profile' }));
+    fireEvent.click(screen.getByRole('button', { name: '프로필' }));
     expect(handleMenu).toHaveBeenCalled();
   });
 
@@ -37,7 +37,7 @@ describe('HomeTitleBar', () => {
     expect(title).toHaveStyle(
       `font-weight: ${typography.title1Bold.fontWeight}`,
     );
-    const profileButton = screen.getByRole('button', { name: 'profile' });
+    const profileButton = screen.getByRole('button', { name: '프로필' });
     expect(profileButton).toHaveStyle(`width: ${spacing.spacing10}`);
     const profileIcon = profileButton.firstChild as HTMLElement;
     expect(profileIcon).toHaveStyle(`color: ${colors.text.default}`);

--- a/src/tests/component/titleBar/loginTitleBar.test.tsx
+++ b/src/tests/component/titleBar/loginTitleBar.test.tsx
@@ -5,7 +5,7 @@ import LoginTitleBar from '@/components/titleBar/loginTitleBar';
 import { colors } from '@/theme/color';
 import { typography } from '@/theme/typography';
 
-describe('LoginTitleBar', () => {
+describe('LoginTitleBar 컴포넌트', () => {
   it('제목을 렌더링한다', () => {
     render(<LoginTitleBar />);
     expect(screen.getByText('로그인')).toBeInTheDocument();

--- a/src/tests/component/titleBar/originTitleBar.test.tsx
+++ b/src/tests/component/titleBar/originTitleBar.test.tsx
@@ -6,21 +6,21 @@ import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
 
-describe('OriginTitleBar', () => {
-  it('renders title and back button', () => {
+describe('OriginTitleBar 컴포넌트', () => {
+  it('제목과 뒤로 가기 버튼을 렌더링한다', () => {
     const handleBack = vi.fn();
-    render(<OriginTitleBar title="Origin" onBack={handleBack} />);
+    render(<OriginTitleBar title="기본" onBack={handleBack} />);
 
     const backButton = screen.getByLabelText('뒤로 가기');
     expect(backButton).toBeInTheDocument();
-    expect(screen.getByText('Origin')).toBeInTheDocument();
+    expect(screen.getByText('기본')).toBeInTheDocument();
 
     fireEvent.click(backButton);
     expect(handleBack).toHaveBeenCalled();
   });
 
-  it('applies styles and has empty right slot', () => {
-    render(<OriginTitleBar title="Origin" onBack={() => {}} />);
+  it('스타일을 적용하고 오른쪽 슬롯이 비어 있다', () => {
+    render(<OriginTitleBar title="기본" onBack={() => {}} />);
 
     const backButton = screen.getByLabelText('뒤로 가기');
     expect(backButton).toHaveStyle(`width: ${spacing.spacing10}`);
@@ -29,7 +29,7 @@ describe('OriginTitleBar', () => {
     const icon = backButton.firstChild as HTMLElement;
     expect(icon).toHaveStyle(`color: ${colors.text.default}`);
 
-    const title = screen.getByText('Origin');
+    const title = screen.getByText('기본');
     expect(title).toHaveStyle(
       `font-weight: ${typography.title1Bold.fontWeight}`,
     );

--- a/src/tests/component/titleBar/titleBar.test.tsx
+++ b/src/tests/component/titleBar/titleBar.test.tsx
@@ -6,29 +6,29 @@ import { colors } from '@/theme/color';
 import { spacing } from '@/theme/spacing';
 import { typography } from '@/theme/typography';
 
-describe('TitleBar', () => {
-  it('renders slots and title', () => {
+describe('TitleBar 컴포넌트', () => {
+  it('슬롯과 제목을 렌더링한다', () => {
     render(
       <TitleBar
-        leftSlot={<button>Left</button>}
-        title="Center"
-        rightSlot={<button>Right</button>}
+        leftSlot={<button>왼쪽</button>}
+        title="가운데"
+        rightSlot={<button>오른쪽</button>}
       />,
     );
-    expect(screen.getByText('Left')).toBeInTheDocument();
-    expect(screen.getByText('Center')).toBeInTheDocument();
-    expect(screen.getByText('Right')).toBeInTheDocument();
+    expect(screen.getByText('왼쪽')).toBeInTheDocument();
+    expect(screen.getByText('가운데')).toBeInTheDocument();
+    expect(screen.getByText('오른쪽')).toBeInTheDocument();
   });
 
-  it('applies correct styles', () => {
-    render(<TitleBar title="Center" />);
+  it('올바른 스타일을 적용한다', () => {
+    render(<TitleBar title="가운데" />);
     const header = screen.getByRole('banner');
     expect(header).toHaveStyle(`height: ${spacing.spacing14}`);
     expect(header).toHaveStyle(
       `border-bottom: 1px solid ${colors.border.default}`,
     );
 
-    const title = screen.getByText('Center');
+    const title = screen.getByText('가운데');
     expect(title).toHaveStyle(`font-size: 1.125rem`);
     expect(title).toHaveStyle(
       `font-weight: ${typography.title1Bold.fontWeight}`,

--- a/src/tests/styles/GlobalStyles.test.tsx
+++ b/src/tests/styles/GlobalStyles.test.tsx
@@ -3,8 +3,8 @@ import { describe, it, expect } from 'vitest';
 
 import GlobalStyle from '@/styles/GlobalStyles';
 
-describe('GlobalStyle', () => {
-  it('renders without crashing', () => {
+describe('GlobalStyle 컴포넌트', () => {
+  it('오류 없이 렌더링된다', () => {
     const { container } = render(<GlobalStyle />);
     expect(container).toBeDefined();
   });


### PR DESCRIPTION
## 📄 변경 사항 요약

- 버튼, 내비게이션 탭, 타이틀바, 앱 등 전반의 테스트 설명과 기대 문자열을 한국어로 번역하고 시나리오를 보강
- 앱 탭 레이블과 접근성 레이블, 스피너 aria 라벨, 프로필 버튼 등 관련 컴포넌트와 목 데이터도 한국어로 정비해 테스트와 실제 동작이 일관되도록 함.

---

## ✅ PR 체크리스트

- [x] PR 제목은 변경 사항을 명확히 나타내나요?
- [x] `develop` 브랜치와 충돌이 없나요?
- [x] 로컬에서 충분히 테스트했나요?
- [x] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #107 

---
