### PR TITLE
[KAN-73] `dropDownPlusText` 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,11 @@ import Button, {
 } from '@/components/button';
 import IconButton, { ToggleIconButton } from '@/components/button/iconButton';
 import LoginButton from '@/components/button/loginButton';
-import { SportsDropDown, TimeSlotDropDown } from '@/components/dropDown';
+import {
+  SportsDropDown,
+  TimeSlotDropDown,
+  DropDownPlusText,
+} from '@/components/dropDown';
 import InputTextWithEmail from '@/components/inputTextWithEmail/index.ts';
 import MatchCard, {
   BasicMatchCard,
@@ -54,6 +58,14 @@ function App() {
   const handleTimeSlotChange = (timeSlots: string[]) => {
     setSelectedTimeSlots(timeSlots);
     console.log('선택된 시간대들:', timeSlots);
+  };
+
+  // DropDownPlusText 상태 관리
+  const [selectedLocation, setSelectedLocation] = useState<string | null>(null);
+
+  const handleLocationChange = (location: string | null) => {
+    setSelectedLocation(location);
+    console.log('선택된 장소:', location);
   };
 
   const tabs = [
@@ -352,6 +364,45 @@ function App() {
               style={{ marginTop: '4px', fontSize: '14px', color: '#6b7280' }}
             >
               ✅ 선택한 항목들이 쉼표로 구분되어 헤더에 표시됩니다
+            </div>
+          </div>
+        </S.MatchCardTestSection>
+
+        <S.MatchCardTestSection>
+          <h2>DropDownPlusText 테스트</h2>
+          <div style={{ padding: '20px', maxWidth: '400px' }}>
+            <h3>장소 선택 드롭다운 + 텍스트 입력 (단일 선택)</h3>
+            <DropDownPlusText onChange={handleLocationChange} />
+            <div
+              style={{
+                marginTop: '16px',
+                padding: '8px',
+                backgroundColor: '#f3f4f6',
+                borderRadius: '4px',
+              }}
+            >
+              <strong>선택된 장소:</strong>{' '}
+              {selectedLocation || '선택되지 않음'}
+            </div>
+            <div
+              style={{ marginTop: '8px', fontSize: '14px', color: '#6b7280' }}
+            >
+              ✅ 일반 옵션 선택 시 즉시 값이 반영됩니다
+            </div>
+            <div
+              style={{ marginTop: '4px', fontSize: '14px', color: '#6b7280' }}
+            >
+              ✅ &apos;기타&apos; 선택 시 텍스트 입력으로 전환됩니다
+            </div>
+            <div
+              style={{ marginTop: '4px', fontSize: '14px', color: '#6b7280' }}
+            >
+              ✅ 텍스트 입력 후 포커스 해제 시 값이 반영됩니다
+            </div>
+            <div
+              style={{ marginTop: '4px', fontSize: '14px', color: '#6b7280' }}
+            >
+              ✅ 되돌아가기 버튼으로 드롭다운으로 복귀합니다
             </div>
           </div>
         </S.MatchCardTestSection>

--- a/src/components/dropDown/constants.ts
+++ b/src/components/dropDown/constants.ts
@@ -28,10 +28,13 @@ export const TIME_SLOT_OPTIONS: DropDownOption[] = [
  * 장소 옵션 목록
  */
 export const LOCATION_OPTIONS: DropDownOption[] = [
-  { value: 'wide_field', label: '넓직한 터' },
-  { value: 'oncheoncheon', label: '온천천 (부산대 ~ 장전역 사이)' },
-  { value: 'geumjeong_elementary', label: '금정초' },
-  { value: 'others', label: '기타' },
+  { value: '넉넉한 터', label: '넉넉한 터' },
+  {
+    value: '온천천 (부산대 ~ 장전역 사이)',
+    label: '온천천 (부산대 ~ 장전역 사이)',
+  },
+  { value: '금정초', label: '금정초' },
+  { value: '기타', label: '기타' },
 ] as const;
 
 /**

--- a/src/components/dropDown/dropDownPlusText.tsx
+++ b/src/components/dropDown/dropDownPlusText.tsx
@@ -1,59 +1,95 @@
 /**
  * DropDownPlusText 복합 컴포넌트
- *
- * 구현 예정:
- *
- * 주요 기능:
- * 1. 기본 상태: DropDown 컴포넌트 표시
- * 2. '기타' 선택 시: InputPlace 컴포넌트로 전환
- * 3. InputPlace의 뒤로가기 클릭 시: DropDown으로 복귀
- * 4. 두 컴포넌트 간 데이터 동기화
- *
- * 상태 관리:
- * - showInput: InputPlace 표시 여부
- * - selectedOption: 드롭다운에서 선택된 옵션
- * - inputValue: InputPlace에서 입력된 값
- *
- * 전환 로직:
- * - DropDown에서 '기타' 선택 → showInput = true
- * - InputPlace에서 뒤로가기 → showInput = false + 드롭다운 '기타' 선택 해제
- *
- * 콜백 처리:
- * - 드롭다운 선택 시: selectedOption이 '기타'가 아니면 바로 onChange 호출
- * - InputPlace 입력 시: inputValue와 함께 onChange 호출
- *
- * TODO: 선택된 항목 텍스트 표시 기능
- * - 일반 항목 선택 시: 선택된 항목의 라벨 표시
- * - '기타' 선택 후 텍스트 입력 시: "기타: {입력한 텍스트}" 형태로 표시
- * - 예: "기타: 사용자가 입력한 장소명"
- *
- * Props:
- * - config: DropDownConfig (location용 설정)
- * - onChange?: (selected: string | null) => void
- * - className?: 추가 CSS 클래스
- *
- * 사용 예시:
- * <DropDownPlusText
- *   config={DROPDOWN_CONFIG.location}
- *   onChange={(location) => console.log('선택된 장소:', location)}
- * />
- * - 드롭다운 선택 시: selectedOption이 '기타'가 아니면 바로 onChange 호출
- * - InputPlace 입력 시: inputValue와 함께 onChange 호출
- *
- * Props:
- * - config: DropDownConfig (location용 설정)
- * - onChange?: (selected: string | null) => void
- * - className?: 추가 CSS 클래스
- *
- * 사용 예시:
- * <DropDownPlusText
- *   config={DROPDOWN_CONFIG.location}
- *   onChange={(location) => console.log('선택된 장소:', location)}
- * />
  */
 
-// TODO: DropDownPlusText 컴포넌트 구현
-// TODO: DropDown과 InputPlace 간 전환 로직 구현
-// TODO: '기타' 옵션 감지 로직 구현
-// TODO: 데이터 동기화 로직 구현
-// TODO: 상태 초기화 로직 구현
+import React, { useState } from 'react';
+
+import { DROPDOWN_CONFIG } from './constants';
+import { DropDown } from './dropDown';
+import { InputPlace } from './inputPlace';
+import type { DropDownConfig } from './types';
+
+export interface DropDownPlusTextProps {
+  /** 드롭다운 설정 (location 설정 사용) */
+  config?: DropDownConfig;
+  /** 선택 변경 콜백 */
+  onChange?: (selected: string | null) => void;
+  /** 추가 CSS 클래스 */
+  className?: string;
+  /** 비활성화 여부 */
+  disabled?: boolean;
+}
+
+export const DropDownPlusText: React.FC<DropDownPlusTextProps> = ({
+  config = DROPDOWN_CONFIG.location,
+  onChange,
+  className,
+  disabled = false,
+}) => {
+  const [showInput, setShowInput] = useState(false);
+  const [selectedOption, setSelectedOption] = useState<string>('');
+  const [inputValue, setInputValue] = useState<string>('');
+
+  // 드롭다운에서 옵션 선택 시 처리
+  const handleDropDownChange = (selected: string | string[]) => {
+    const selectedValue = Array.isArray(selected) ? selected[0] : selected;
+
+    if (selectedValue === '기타') {
+      // '기타' 선택 시 입력 모드로 전환
+      setShowInput(true);
+      setSelectedOption('');
+    } else {
+      // 일반 옵션 선택 시 - 이제 value와 label이 동일하므로 그대로 전달
+      setSelectedOption(selectedValue);
+      setInputValue('');
+      onChange?.(selectedValue);
+    }
+  };
+
+  // InputPlace에서 뒤로가기 클릭 시 처리
+  const handleBackClick = () => {
+    setShowInput(false);
+    setSelectedOption('');
+    setInputValue('');
+    onChange?.(null);
+  };
+
+  // InputPlace에서 입력값 변경 시 처리
+  const handleInputChange = (value: string) => {
+    setInputValue(value);
+    // 실시간으로 상위 컴포넌트에 전달하지 않고 blur 시점에 전달
+  };
+
+  // InputPlace에서 포커스 해제 시 처리
+  const handleInputBlur = () => {
+    if (inputValue.trim()) {
+      onChange?.(inputValue.trim());
+    } else {
+      onChange?.(null);
+    }
+  };
+
+  // 현재 표시할 컴포넌트 결정
+  if (showInput) {
+    return (
+      <InputPlace
+        value={inputValue}
+        onChange={handleInputChange}
+        onBackClick={handleBackClick}
+        onBlur={handleInputBlur}
+        placeholder="장소를 입력해주세요"
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <DropDown
+      config={config}
+      onChange={handleDropDownChange}
+      className={className}
+      disabled={disabled}
+      initialSelected={selectedOption}
+    />
+  );
+};

--- a/src/components/dropDown/index.ts
+++ b/src/components/dropDown/index.ts
@@ -6,6 +6,10 @@
 export { DropDown } from './dropDown';
 export { useDropDown } from './useDropDown';
 
+// 복합 컴포넌트들
+export { DropDownPlusText } from './dropDownPlusText';
+export { InputPlace } from './inputPlace';
+
 // 프리셋 컴포넌트들
 export {
   SportsDropDown,
@@ -31,6 +35,8 @@ export type {
   SportsDropDownProps,
   TimeSlotDropDownProps,
   LocationDropDownProps,
+  DropDownPlusTextProps,
+  InputPlaceProps,
   UseDropDownConfig,
   UseDropDownReturn,
 } from './types';

--- a/src/components/dropDown/inputPlace.styled.ts
+++ b/src/components/dropDown/inputPlace.styled.ts
@@ -1,0 +1,86 @@
+/**
+ * InputPlace 컴포넌트의 Emotion 스타일 정의
+ */
+
+import styled from '@emotion/styled';
+
+/**
+ * 전체 입력 컨테이너
+ */
+export const InputContainer = styled.div`
+  position: relative;
+  width: 100%;
+  max-width: 360px;
+  background-color: white;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+`;
+
+/**
+ * 입력 헤더 (라벨 + 액션 버튼들)
+ */
+export const InputHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid #f3f4f6;
+  font-size: 16px;
+  font-weight: 500;
+  color: #111827;
+`;
+
+/**
+ * 실제 입력 필드
+ */
+export const InputField = styled.input`
+  width: 100%;
+  padding: 12px 16px;
+  border: none;
+  outline: none;
+  font-size: 16px;
+  color: #111827;
+  background: transparent;
+
+  &::placeholder {
+    color: #9ca3af;
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+/**
+ * 액션 버튼들 컨테이너
+ */
+export const InputActions = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+/**
+ * 액션 버튼 (지우기, 뒤로가기)
+ */
+export const ActionButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: #6b7280;
+  font-size: 14px;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: #374151;
+  }
+
+  &:focus {
+    outline: none;
+    color: #3b82f6;
+  }
+`;

--- a/src/components/dropDown/inputPlace.tsx
+++ b/src/components/dropDown/inputPlace.tsx
@@ -1,43 +1,92 @@
 /**
  * InputPlace 컴포넌트 (장소 입력)
- *
- * 구현 예정:
- *
- * 컴포넌트 구조:
- * 1. InputHeader: '장소 입력' 레이블 + 뒤로가기 버튼
- * 2. TextInput: 실제 텍스트 입력 필드
- * 3. InputActions: 지우기(X) + 새로고침 버튼
- *
- * 주요 기능:
- * - 텍스트 입력 및 실시간 상태 업데이트
- * - 뒤로가기 버튼 클릭 시 onBackClick 콜백 호출
- * - 입력값 변경 시 onChange 콜백 호출
- * - 지우기 버튼으로 입력값 초기화
- * - 새로고침 버튼 (필요시 추가 기능)
- *
- * TODO: 입력된 텍스트를 DropDownPlusText에서 표시하는 기능
- * - 입력값이 있을 때: "기타: {입력한 텍스트}" 형태로 부모 컴포넌트에 전달
- * - 입력값이 없을 때: 빈 상태 또는 기본 플레이스홀더 표시
- * - 실시간 입력 반영으로 부모 컴포넌트의 헤더 텍스트 업데이트
- *
- * Props:
- * - value?: 입력값
- * - onChange?: 입력값 변경 콜백
- * - onBackClick?: 뒤로가기 버튼 클릭 콜백
- * - placeholder?: placeholder 텍스트
- * - className?: 추가 CSS 클래스
- *
- * 사용 예시:
- * <InputPlace
- *   value={inputValue}
- *   onChange={setInputValue}
- *   onBackClick={() => setShowInput(false)}
- *   placeholder="장소를 입력해주세요"
- * />
  */
 
-// TODO: InputPlace 컴포넌트 구현
-// TODO: InputHeader 서브 컴포넌트 구현
-// TODO: TextInput 서브 컴포넌트 구현
-// TODO: InputActions 서브 컴포넌트 구현
-// TODO: 뒤로가기 버튼 아이콘 추가
+import React, { useRef, useEffect } from 'react';
+
+import { DROPDOWN_ICONS } from './constants';
+import {
+  InputContainer,
+  InputHeader,
+  InputField,
+  InputActions,
+  ActionButton,
+} from './inputPlace.styled.ts';
+
+export interface InputPlaceProps {
+  /** 입력값 */
+  value?: string;
+  /** 입력값 변경 콜백 */
+  onChange?: (value: string) => void;
+  /** 뒤로가기 버튼 클릭 콜백 */
+  onBackClick?: () => void;
+  /** placeholder 텍스트 */
+  placeholder?: string;
+  /** 추가 CSS 클래스 */
+  className?: string;
+  /** 포커스 해제 시 콜백 */
+  onBlur?: () => void;
+}
+
+export const InputPlace: React.FC<InputPlaceProps> = ({
+  value = '',
+  onChange,
+  onBackClick,
+  placeholder = '장소를 입력해주세요',
+  className,
+  onBlur,
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // 컴포넌트 마운트 시 자동 포커스
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, []);
+
+  const handleClearClick = () => {
+    onChange?.('');
+    inputRef.current?.focus();
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange?.(e.target.value);
+  };
+
+  const handleInputBlur = () => {
+    onBlur?.();
+  };
+
+  return (
+    <InputContainer className={className}>
+      <InputHeader>
+        <span>장소 입력</span>
+        <InputActions>
+          <ActionButton
+            type="button"
+            onClick={handleClearClick}
+            aria-label="입력 내용 지우기"
+          >
+            {DROPDOWN_ICONS.CLEAR}
+          </ActionButton>
+          <ActionButton
+            type="button"
+            onClick={onBackClick}
+            aria-label="드롭다운으로 돌아가기"
+          >
+            {DROPDOWN_ICONS.REFRESH}
+          </ActionButton>
+        </InputActions>
+      </InputHeader>
+      <InputField
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={handleInputChange}
+        onBlur={handleInputBlur}
+        placeholder={placeholder}
+      />
+    </InputContainer>
+  );
+};

--- a/src/components/dropDown/types.ts
+++ b/src/components/dropDown/types.ts
@@ -104,3 +104,32 @@ export interface LocationDropDownProps {
   /** 비활성화 여부 */
   disabled?: boolean;
 }
+
+/**
+ * 복합 컴포넌트 Props 타입들
+ */
+export interface DropDownPlusTextProps {
+  /** 드롭다운 설정 */
+  config?: DropDownConfig;
+  /** 선택 변경 콜백 */
+  onChange?: (selected: string | null) => void;
+  /** 추가 CSS 클래스 */
+  className?: string;
+  /** 비활성화 여부 */
+  disabled?: boolean;
+}
+
+export interface InputPlaceProps {
+  /** 입력값 */
+  value?: string;
+  /** 입력값 변경 콜백 */
+  onChange?: (value: string) => void;
+  /** 뒤로가기 버튼 클릭 콜백 */
+  onBackClick?: () => void;
+  /** placeholder 텍스트 */
+  placeholder?: string;
+  /** 추가 CSS 클래스 */
+  className?: string;
+  /** 포커스 해제 시 콜백 */
+  onBlur?: () => void;
+}


### PR DESCRIPTION
## 📄 변경 사항 요약

- `dropDownPlusText` 구현
  - 디자인과 다르게, 텍스트 입력시 입력창이 아래에 나오도록 구현
  - 텍스트 입력 후 포커스 해제 시 값이 반영

---

## ✅ PR 체크리스트

- [x] PR 제목은 변경 사항을 명확히 나타내나요?
- [x] `develop` 브랜치와 충돌이 없나요?
- [x] 로컬에서 충분히 테스트했나요?
- [x] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #124 

---

## 📸 스크린샷 또는 동영상 (선택)

<img width="369" height="108" alt="image" src="https://github.com/user-attachments/assets/47cf7b0e-95ec-44e4-bbf1-2b70bcbd576b" />

<img width="370" height="158" alt="image" src="https://github.com/user-attachments/assets/0fb0e4ce-ee2f-4aea-8dde-316b8dce9678" />

---

## 📌 기타 참고 사항

- 피그마 디자인과 다르게 구현했는데, 피드백 부탁드립니다.
