### PR TITLE
[KAN-86] fix(eslint,loginbutton): 규칙 컴포넌트 예외 목록 제거 후 디렉터리 기반 override 추가

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -51,12 +51,6 @@ export default tseslint.config(
         {
           html: 'enforce',
           custom: 'enforce',
-          exceptions: [
-            'Button',
-            'ToggleButton',
-            'StyledButton',
-            'S.StyledButton',
-          ],
         },
       ],
       'import/order': [
@@ -98,6 +92,15 @@ export default tseslint.config(
       globals: {
         ...globals.node,
       },
+    },
+  },
+  {
+    files: [
+      'src/components/button/**/*.{ts,tsx}',
+      'src/tests/component/button/**/*.{ts,tsx}',
+    ],
+    rules: {
+      'react/jsx-props-no-spreading': 'off',
     },
   },
   eslintConfigPrettier,

--- a/src/components/button/loginButton/loginButton.tsx
+++ b/src/components/button/loginButton/loginButton.tsx
@@ -22,10 +22,7 @@ const createLoginButton = <P extends ButtonProps | ToggleButtonProps>(
     ...rest
   }: BaseLoginButtonProps<P>) => {
     return (
-      <Component
-        variant="login"
-        {...(rest as P)} /* eslint-disable-line react/jsx-props-no-spreading */
-      >
+      <Component variant="login" {...(rest as P)}>
         {children}
       </Component>
     );


### PR DESCRIPTION
## 📄 변경 사항 요약

- react/jsx-props-no-spreading 규칙에서 컴포넌트별 예외 목록을 제거하고 버튼 컴포넌트 및 해당 테스트 디렉터리에 대해 디렉터리 기반 override를 추가
- override 적용에 따라 LoginButton 구현에서 불필요했던 eslint 비활성화 주석을 제거

---

## ✅ PR 체크리스트

- [x] PR 제목은 변경 사항을 명확히 나타내나요?
- [x] `develop` 브랜치와 충돌이 없나요?
- [x] 로컬에서 충분히 테스트했나요?
- [x] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #144 

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Simplified component JSX formatting for consistency and readability by removing inline lint directives. No visual or behavioral changes.
- Chores
  - Updated linting configuration with targeted overrides to reduce inline suppressions and standardize prop handling across specific components.
- No User-Facing Changes
  - UI and functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->