### PR TITLE
[KAN-88] DropdownPlusText를 LocationDropDown으로 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import LoginButton from '@/components/button/loginButton';
 import {
   SportsDropDown,
   TimeSlotDropDown,
-  DropDownPlusText,
+  LocationDropDownWithInput,
 } from '@/components/dropDown';
 import InputTextWithEmail from '@/components/inputTextWithEmail/index.ts';
 import {
@@ -60,7 +60,7 @@ function App() {
     console.log('선택된 시간대들:', timeSlots);
   };
 
-  // DropDownPlusText 상태 관리
+  // LocationDropDownWithInput 상태 관리
   const [selectedLocation, setSelectedLocation] = useState<string | null>(null);
 
   const handleLocationChange = (location: string | null) => {
@@ -308,10 +308,10 @@ function App() {
         </S.MatchCardTestSection>
 
         <S.MatchCardTestSection>
-          <h2>DropDownPlusText 테스트</h2>
+          <h2>LocationDropDownWithInput 테스트</h2>
           <div style={{ padding: '20px', maxWidth: '400px' }}>
             <h3>장소 선택 드롭다운 + 텍스트 입력 (단일 선택)</h3>
-            <DropDownPlusText onChange={handleLocationChange} />
+            <LocationDropDownWithInput onChange={handleLocationChange} />
             <div
               style={{
                 marginTop: '16px',

--- a/src/components/dropDown/index.ts
+++ b/src/components/dropDown/index.ts
@@ -7,7 +7,6 @@ export { DropDown } from './dropDown';
 export { useDropDown } from './useDropDown';
 
 // 복합 컴포넌트들
-export { DropDownPlusText } from './dropDownPlusText';
 export { InputPlace } from './inputPlace';
 
 // 프리셋 컴포넌트들
@@ -16,6 +15,9 @@ export {
   TimeSlotDropDown,
   LocationDropDown,
 } from './dropDownPresets';
+
+// 복합 컴포넌트들
+export { LocationDropDown as LocationDropDownWithInput } from './locationDropDown';
 
 // 설정 객체와 상수들
 export {
@@ -35,7 +37,7 @@ export type {
   SportsDropDownProps,
   TimeSlotDropDownProps,
   LocationDropDownProps,
-  DropDownPlusTextProps,
+  LocationDropDownWithInputProps,
   InputPlaceProps,
   UseDropDownConfig,
   UseDropDownReturn,

--- a/src/components/dropDown/locationDropDown.tsx
+++ b/src/components/dropDown/locationDropDown.tsx
@@ -1,5 +1,6 @@
 /**
- * DropDownPlusText 복합 컴포넌트
+ * 장소 선택 드롭다운 (단일 선택)
+ * "기타" 선택 시 InputPlace로 전환되는 복합 컴포넌트
  */
 
 import React, { useState } from 'react';
@@ -7,21 +8,9 @@ import React, { useState } from 'react';
 import { DROPDOWN_CONFIG } from './constants';
 import { DropDown } from './dropDown';
 import { InputPlace } from './inputPlace';
-import type { DropDownConfig } from './types';
+import type { LocationDropDownWithInputProps } from './types';
 
-export interface DropDownPlusTextProps {
-  /** 드롭다운 설정 (location 설정 사용) */
-  config?: DropDownConfig;
-  /** 선택 변경 콜백 */
-  onChange?: (selected: string | null) => void;
-  /** 추가 CSS 클래스 */
-  className?: string;
-  /** 비활성화 여부 */
-  disabled?: boolean;
-}
-
-export const DropDownPlusText: React.FC<DropDownPlusTextProps> = ({
-  config = DROPDOWN_CONFIG.location,
+export const LocationDropDown: React.FC<LocationDropDownWithInputProps> = ({
   onChange,
   className,
   disabled = false,
@@ -39,7 +28,7 @@ export const DropDownPlusText: React.FC<DropDownPlusTextProps> = ({
       setShowInput(true);
       setSelectedOption('');
     } else {
-      // 일반 옵션 선택 시 - 이제 value와 label이 동일하므로 그대로 전달
+      // 일반 옵션 선택 시
       setSelectedOption(selectedValue);
       setInputValue('');
       onChange?.(selectedValue);
@@ -57,7 +46,6 @@ export const DropDownPlusText: React.FC<DropDownPlusTextProps> = ({
   // InputPlace에서 입력값 변경 시 처리
   const handleInputChange = (value: string) => {
     setInputValue(value);
-    // 실시간으로 상위 컴포넌트에 전달하지 않고 blur 시점에 전달
   };
 
   // InputPlace에서 포커스 해제 시 처리
@@ -85,7 +73,7 @@ export const DropDownPlusText: React.FC<DropDownPlusTextProps> = ({
 
   return (
     <DropDown
-      config={config}
+      config={DROPDOWN_CONFIG.location}
       onChange={handleDropDownChange}
       className={className}
       disabled={disabled}

--- a/src/components/dropDown/types.ts
+++ b/src/components/dropDown/types.ts
@@ -105,12 +105,7 @@ export interface LocationDropDownProps {
   disabled?: boolean;
 }
 
-/**
- * 복합 컴포넌트 Props 타입들
- */
-export interface DropDownPlusTextProps {
-  /** 드롭다운 설정 */
-  config?: DropDownConfig;
+export interface LocationDropDownWithInputProps {
   /** 선택 변경 콜백 */
   onChange?: (selected: string | null) => void;
   /** 추가 CSS 클래스 */
@@ -119,6 +114,9 @@ export interface DropDownPlusTextProps {
   disabled?: boolean;
 }
 
+/**
+ * 복합 컴포넌트 Props 타입들
+ */
 export interface InputPlaceProps {
   /** 입력값 */
   value?: string;


### PR DESCRIPTION
## 📄 변경 사항 요약

- DropdownPlusText를 LocationDropDown으로 리팩토링
  - 필요없는 DropdownPlusText 삭제

---

## ✅ PR 체크리스트

- [x] PR 제목은 변경 사항을 명확히 나타내나요?
- [x] `develop` 브랜치와 충돌이 없나요?
- [x] 로컬에서 충분히 테스트했나요?
- [x] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #151 

