### PR TITLE
[KAN-89] useDropDown 훅에서 타입 분기 처리 통합

### DIFF
--- a/src/components/dropDown/dropDownPresets.tsx
+++ b/src/components/dropDown/dropDownPresets.tsx
@@ -7,45 +7,10 @@ import React from 'react';
 import { DROPDOWN_CONFIG } from './constants';
 import { DropDown } from './dropDown';
 import type {
-  DropDownConfig,
   SportsDropDownProps,
   TimeSlotDropDownProps,
   LocationDropDownProps,
 } from './types';
-
-/**
- * 공통 타입 가드 헬퍼 함수들
- */
-const isSingleSelection = (selected: string | string[]): selected is string => {
-  return typeof selected === 'string';
-};
-
-const isMultipleSelection = (
-  selected: string | string[],
-): selected is string[] => {
-  return Array.isArray(selected);
-};
-
-/**
- * 타입별 onChange 핸들러를 생성하는 고차 함수
- */
-const createTypedOnChangeHandler = <T extends string | string[]>(
-  config: DropDownConfig,
-  onChange?: (selected: T) => void,
-) => {
-  return (selected: string | string[]) => {
-    if (!onChange) return;
-
-    if (config.selectionMode === 'single' && isSingleSelection(selected)) {
-      (onChange as (selected: string) => void)(selected);
-    } else if (
-      config.selectionMode === 'multiple' &&
-      isMultipleSelection(selected)
-    ) {
-      (onChange as (selected: string[]) => void)(selected);
-    }
-  };
-};
 
 /**
  * 종목 선택 드롭다운 (단일 선택)
@@ -55,10 +20,10 @@ export const SportsDropDown: React.FC<SportsDropDownProps> = ({
   className,
   disabled = false,
 }) => {
-  const handleChange = createTypedOnChangeHandler(
-    DROPDOWN_CONFIG.sports,
-    onChange,
-  );
+  const handleChange = onChange
+    ? (selected: string | string[]) =>
+        (onChange as (selected: string) => void)(selected as string)
+    : undefined;
 
   return (
     <DropDown
@@ -78,10 +43,10 @@ export const TimeSlotDropDown: React.FC<TimeSlotDropDownProps> = ({
   className,
   disabled = false,
 }) => {
-  const handleChange = createTypedOnChangeHandler(
-    DROPDOWN_CONFIG.timeSlot,
-    onChange,
-  );
+  const handleChange = onChange
+    ? (selected: string | string[]) =>
+        (onChange as (selected: string[]) => void)(selected as string[])
+    : undefined;
 
   return (
     <DropDown
@@ -101,10 +66,10 @@ export const LocationDropDown: React.FC<LocationDropDownProps> = ({
   className,
   disabled = false,
 }) => {
-  const handleChange = createTypedOnChangeHandler(
-    DROPDOWN_CONFIG.location,
-    onChange,
-  );
+  const handleChange = onChange
+    ? (selected: string | string[]) =>
+        (onChange as (selected: string) => void)(selected as string)
+    : undefined;
 
   return (
     <DropDown

--- a/src/components/dropDown/useDropDown.ts
+++ b/src/components/dropDown/useDropDown.ts
@@ -76,13 +76,13 @@ export const useDropDown = ({
 
       setSelectedItems(newSelected);
 
-      // 상위 컴포넌트로 콜백 호출
+      // 상위 컴포넌트로 콜백 호출 (selectionMode에 따라 적절한 타입 호출)
       if (onChange) {
-        onChange(
-          config.selectionMode === 'single'
-            ? newSelected[0] || ''
-            : newSelected,
-        );
+        if (config.selectionMode === 'single') {
+          (onChange as (selected: string) => void)(newSelected[0] || '');
+        } else {
+          (onChange as (selected: string[]) => void)(newSelected);
+        }
       }
     },
     [config.selectionMode, selectedItems, onChange],
@@ -92,7 +92,11 @@ export const useDropDown = ({
   const clearSelection = useCallback(() => {
     setSelectedItems([]);
     if (onChange) {
-      onChange(config.selectionMode === 'single' ? '' : []);
+      if (config.selectionMode === 'single') {
+        (onChange as (selected: string) => void)('');
+      } else {
+        (onChange as (selected: string[]) => void)([]);
+      }
     }
   }, [config.selectionMode, onChange]);
 


### PR DESCRIPTION
## 📄 변경 사항 요약

- https://github.com/kakao-tech-campus-3rd-step3/Team13_FE/pull/131#discussion_r2417118418
- useDropDown 훅에서 타입 분기 처리와 상태 관리를 통합하여 코드 간결화
    - 단일 선택 시 `string`, 다중 선택 시 `string[]`로 타입 캐스팅하여 호출
- createTypedOnChangeHandler 함수 제거

---

## ✅ PR 체크리스트

- [x] PR 제목은 변경 사항을 명확히 나타내나요?
- [x] `develop` 브랜치와 충돌이 없나요?
- [x] 로컬에서 충분히 테스트했나요?
- [x] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #152

