### PR TITLE
[KAN-92] feat(msw): msw 시나리오 작성

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,7 +1,0 @@
-import { http, HttpResponse } from 'msw';
-
-export const handlers = [
-  http.get('/api/greeting', () =>
-    HttpResponse.json({ greeting: '안녕하세요' }),
-  ),
-];

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from 'msw';
+
+import { createErrorResponse } from '../sharedErrors';
+
+export const authHandlers = [
+  http.get('*/api/v1/auth/kakao', ({ request }) => {
+    const redirectUri = new URL(request.url).searchParams.get('redirectUri');
+
+    return HttpResponse.json({
+      url: `https://kauth.kakao.com/oauth/authorize?client_id=mockClientId&redirect_uri=${
+        redirectUri ?? 'https://localhost:5173/auth/kakao'
+      }&response_type=code`,
+    });
+  }),
+  http.get('*/api/v1/auth/kakao/callback', ({ request }) => {
+    const url = new URL(request.url);
+    const code = url.searchParams.get('code');
+
+    if (!code) {
+      return createErrorResponse('AUTH_MISSING_CODE');
+    }
+
+    if (code === 'invalid') {
+      return createErrorResponse('AUTH_INVALID_CODE');
+    }
+
+    return HttpResponse.json({
+      accessToken: 'mock-access-token',
+      refreshToken: 'mock-refresh-token',
+      isNewMember: code === 'signup',
+    });
+  }),
+];

--- a/src/mocks/handlers/certification.ts
+++ b/src/mocks/handlers/certification.ts
@@ -1,0 +1,83 @@
+import { http, HttpResponse } from 'msw';
+
+import { createErrorResponse } from '../sharedErrors';
+
+type CertificationState = {
+  email: string | null;
+  verified: boolean;
+  lastSentAt: string | null;
+  verifiedAt: string | null;
+};
+
+const certificationState: CertificationState = {
+  email: null,
+  verified: false,
+  lastSentAt: null,
+  verifiedAt: null,
+};
+
+export const resetCertificationState = () => {
+  certificationState.email = null;
+  certificationState.verified = false;
+  certificationState.lastSentAt = null;
+  certificationState.verifiedAt = null;
+};
+
+export const certificationHandlers = [
+  http.post('*/api/v1/members/me/certification/email', async ({ request }) => {
+    const body = (await request.json()) as { email?: string };
+
+    if (!body?.email) {
+      return createErrorResponse('EMAIL_REQUIRED');
+    }
+
+    if (body.email === 'already@kan.com' && certificationState.verified) {
+      return createErrorResponse('EMAIL_ALREADY_VERIFIED');
+    }
+
+    if (body.email === 'limit@kan.com') {
+      return createErrorResponse('EMAIL_RATE_LIMITED');
+    }
+
+    const now = new Date().toISOString();
+
+    certificationState.email = body.email;
+    certificationState.lastSentAt = now;
+    certificationState.verified = false;
+    certificationState.verifiedAt = null;
+
+    return HttpResponse.json({
+      email: body.email,
+      sentAt: now,
+    });
+  }),
+  http.post('*/api/v1/members/me/certification/verify', async ({ request }) => {
+    const body = (await request.json()) as { code?: string };
+
+    if (!certificationState.email) {
+      return createErrorResponse('EMAIL_NOT_REQUESTED');
+    }
+
+    if (!body?.code || body.code !== '000000') {
+      return createErrorResponse('EMAIL_INVALID_TOKEN');
+    }
+
+    const now = new Date().toISOString();
+
+    certificationState.verified = true;
+    certificationState.verifiedAt = now;
+
+    return HttpResponse.json({
+      email: certificationState.email,
+      verifiedAt: now,
+    });
+  }),
+  http.get('*/api/v1/members/me/certification/status', () =>
+    HttpResponse.json({
+      email: certificationState.email,
+      verified: certificationState.verified,
+      lastSentAt: certificationState.lastSentAt,
+      verifiedAt: certificationState.verifiedAt,
+    }),
+  ),
+];

--- a/src/mocks/handlers/common.ts
+++ b/src/mocks/handlers/common.ts
@@ -1,0 +1,8 @@
+import type { HttpHandler } from 'msw';
+import { http, HttpResponse } from 'msw';
+
+const GREETING_RESPONSE = Object.freeze({ greeting: '안녕하세요' });
+
+export const commonHandlers: readonly HttpHandler[] = [
+  http.get('*/api/greeting', () => HttpResponse.json(GREETING_RESPONSE)),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,0 +1,11 @@
+import { authHandlers } from './auth';
+import { certificationHandlers } from './certification';
+import { commonHandlers } from './common';
+import { profileHandlers } from './profile';
+
+export const handlers = [
+  ...commonHandlers,
+  ...authHandlers,
+  ...certificationHandlers,
+  ...profileHandlers,
+];

--- a/src/mocks/handlers/profile.ts
+++ b/src/mocks/handlers/profile.ts
@@ -1,0 +1,127 @@
+import { http, HttpResponse } from 'msw';
+
+import { createErrorResponse } from '../sharedErrors';
+
+type MemberProfile = {
+  memberId: number;
+  name: string;
+  description: string;
+  imageUrl: string;
+};
+
+const defaultMembers: MemberProfile[] = [
+  {
+    memberId: 101,
+    name: '김대영',
+    description: '부산대학교 농구 동아리 주장',
+    imageUrl: 'https://example.com/avatar/kimdaeyoung.png',
+  },
+  {
+    memberId: 102,
+    name: '부산대학교 리그',
+    description: '부산대학교 농구 리그 운영진',
+    imageUrl: 'https://example.com/avatar/busan-league.png',
+  },
+];
+
+let myProfile: MemberProfile = { ...defaultMembers[0] };
+
+const memberDirectory = new Map<number, MemberProfile>();
+
+const seedDirectory = () => {
+  memberDirectory.clear();
+  memberDirectory.set(myProfile.memberId, myProfile);
+  for (const member of defaultMembers.slice(1)) {
+    memberDirectory.set(member.memberId, { ...member });
+  }
+};
+
+export const resetProfileState = () => {
+  myProfile = { ...defaultMembers[0] };
+  seedDirectory();
+};
+
+seedDirectory();
+
+const isValidUrl = (url: string) => {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export const profileHandlers = [
+  http.get('*/api/v2/members/me/profile', () =>
+    HttpResponse.json({
+      memberId: myProfile.memberId,
+      name: myProfile.name,
+      description: myProfile.description,
+      imageUrl: myProfile.imageUrl,
+    }),
+  ),
+  http.get('*/api/v2/members/:memberId/profile', ({ params }) => {
+    const memberId = Number(params.memberId);
+
+    if (Number.isNaN(memberId)) {
+      return createErrorResponse('PROFILE_NOT_FOUND');
+    }
+
+    const profile = memberDirectory.get(memberId);
+
+    if (!profile) {
+      return createErrorResponse('PROFILE_NOT_FOUND');
+    }
+
+    return HttpResponse.json(profile);
+  }),
+  http.patch('*/api/v2/members/me/profile/name', async ({ request }) => {
+    const body = (await request.json()) as { name?: string };
+    const name = body?.name?.trim();
+
+    if (!name || name.length < 2 || name.length > 20) {
+      return createErrorResponse('PROFILE_INVALID_NAME');
+    }
+
+    myProfile = {
+      ...myProfile,
+      name,
+    };
+    memberDirectory.set(myProfile.memberId, myProfile);
+
+    return HttpResponse.json({ name });
+  }),
+  http.patch('*/api/v2/members/me/profile/description', async ({ request }) => {
+    const body = (await request.json()) as { description?: string };
+    const description = body?.description ?? '';
+
+    if (description.length > 150) {
+      return createErrorResponse('PROFILE_INVALID_DESCRIPTION');
+    }
+
+    myProfile = {
+      ...myProfile,
+      description,
+    };
+    memberDirectory.set(myProfile.memberId, myProfile);
+
+    return HttpResponse.json({ description });
+  }),
+  http.patch('*/api/v2/members/me/profile/image-url', async ({ request }) => {
+    const body = (await request.json()) as { imageUrl?: string };
+    const imageUrl = body?.imageUrl?.trim();
+
+    if (!imageUrl || !isValidUrl(imageUrl)) {
+      return createErrorResponse('PROFILE_INVALID_IMAGE_URL');
+    }
+
+    myProfile = {
+      ...myProfile,
+      imageUrl,
+    };
+    memberDirectory.set(myProfile.memberId, myProfile);
+
+    return HttpResponse.json({ imageUrl });
+  }),
+];

--- a/src/mocks/sharedErrors.ts
+++ b/src/mocks/sharedErrors.ts
@@ -1,0 +1,79 @@
+import { HttpResponse } from 'msw';
+
+export type ErrorCode =
+  | 'AUTH_MISSING_CODE'
+  | 'AUTH_INVALID_CODE'
+  | 'EMAIL_REQUIRED'
+  | 'EMAIL_ALREADY_VERIFIED'
+  | 'EMAIL_RATE_LIMITED'
+  | 'EMAIL_NOT_REQUESTED'
+  | 'EMAIL_INVALID_TOKEN'
+  | 'PROFILE_NOT_FOUND'
+  | 'PROFILE_INVALID_NAME'
+  | 'PROFILE_INVALID_DESCRIPTION'
+  | 'PROFILE_INVALID_IMAGE_URL';
+
+const errorCatalog: Record<ErrorCode, { status: number; message: string }> = {
+  AUTH_MISSING_CODE: {
+    status: 400,
+    message: '인가 코드를 찾을 수 없습니다.',
+  },
+  AUTH_INVALID_CODE: {
+    status: 401,
+    message: '유효하지 않은 카카오 인가 코드입니다.',
+  },
+  EMAIL_REQUIRED: {
+    status: 400,
+    message: '이메일 정보가 필요합니다.',
+  },
+  EMAIL_ALREADY_VERIFIED: {
+    status: 409,
+    message: '이미 인증이 완료된 이메일입니다.',
+  },
+  EMAIL_RATE_LIMITED: {
+    status: 429,
+    message: '인증 이메일 전송 제한을 초과했습니다.',
+  },
+  EMAIL_NOT_REQUESTED: {
+    status: 400,
+    message: '먼저 인증 이메일을 요청해 주세요.',
+  },
+  EMAIL_INVALID_TOKEN: {
+    status: 400,
+    message: '잘못된 인증 코드입니다.',
+  },
+  PROFILE_NOT_FOUND: {
+    status: 404,
+    message: '요청한 사용자를 찾을 수 없습니다.',
+  },
+  PROFILE_INVALID_NAME: {
+    status: 400,
+    message: '닉네임은 2~20자 사이여야 합니다.',
+  },
+  PROFILE_INVALID_DESCRIPTION: {
+    status: 400,
+    message: '소개글은 0~150자 사이여야 합니다.',
+  },
+  PROFILE_INVALID_IMAGE_URL: {
+    status: 400,
+    message: '잘못된 이미지 URL 형식입니다.',
+  },
+};
+
+export type ApiErrorResponse<Code extends ErrorCode = ErrorCode> = {
+  error: { code: Code; message: string };
+};
+
+export const createErrorResponse = (code: ErrorCode) => {
+  const { status, message } = errorCatalog[code];
+
+  return HttpResponse.json<ApiErrorResponse>(
+    {
+      error: {
+        code,
+        message,
+      },
+    },
+    { status },
+  );
+};

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,8 +1,8 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import { afterAll, afterEach, beforeAll } from 'vitest';
 
 import { server } from '@/mocks/server';
 
-beforeAll(() => server.listen());
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());

--- a/src/tests/mocks/mswHandlers.axios.test.ts
+++ b/src/tests/mocks/mswHandlers.axios.test.ts
@@ -1,0 +1,77 @@
+import axios, { type AxiosError } from 'axios';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { resetCertificationState } from '@/mocks/handlers/certification';
+import { resetProfileState } from '@/mocks/handlers/profile';
+import type { ApiErrorResponse } from '@/mocks/sharedErrors';
+
+const client = axios.create({
+  baseURL: 'http://localhost',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+const expectAxiosError = async <T>(
+  request: Promise<unknown>,
+  assertions: (error: AxiosError<T>) => void,
+) => {
+  await expect(request).rejects.toSatisfy((error: unknown) => {
+    if (!axios.isAxiosError<T>(error)) {
+      return false;
+    }
+
+    assertions(error);
+    return true;
+  });
+};
+
+describe('MSW와 axios 통합 동작', () => {
+  beforeEach(() => {
+    resetCertificationState();
+    resetProfileState();
+  });
+
+  it('카카오 OAuth URL 요청을 msw가 가로채어 응답한다', async () => {
+    const response = await client.get<{ url: string }>('/api/v1/auth/kakao', {
+      params: { redirectUri: 'https://kan.example.com/auth/kakao' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.data.url).toContain(
+      'redirect_uri=https://kan.example.com/auth/kakao',
+    );
+  });
+
+  it('axios POST 요청에서도 에러 응답을 재현할 수 있다', async () => {
+    await expectAxiosError<ApiErrorResponse>(
+      client.post('/api/v1/members/me/certification/email', {}),
+      (error) => {
+        const { response } = error;
+
+        expect(response?.status).toBe(400);
+        expect(response?.data.error.code).toBe('EMAIL_REQUIRED');
+      },
+    );
+  });
+
+  it('프로필 수정 요청이 axios를 통해 성공적으로 처리된다', async () => {
+    const response = await client.patch<{ name: string }>(
+      '/api/v2/members/me/profile/name',
+      { name: '부산대학교 농구 주장' },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ name: '부산대학교 농구 주장' });
+
+    const profile = await client.get<{
+      memberId: number;
+      name: string;
+      description: string;
+      imageUrl: string;
+    }>('/api/v2/members/me/profile');
+
+    expect(profile.status).toBe(200);
+    expect(profile.data).toMatchObject({ name: '부산대학교 농구 주장' });
+  });
+});

--- a/src/tests/mocks/mswHandlers.test.ts
+++ b/src/tests/mocks/mswHandlers.test.ts
@@ -1,0 +1,356 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetCertificationState } from '@/mocks/handlers/certification';
+import { resetProfileState } from '@/mocks/handlers/profile';
+
+const baseUrl = 'http://localhost';
+
+type RequestInitWithJson = Omit<RequestInit, 'body'> & { body?: unknown };
+
+const requestJson = async <T>(path: string, init?: RequestInitWithJson) => {
+  const { body, headers, ...rest } = init ?? {};
+  const response = await fetch(`${baseUrl}${path}`, {
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body:
+      body === undefined || typeof body === 'string'
+        ? (body as BodyInit | undefined)
+        : JSON.stringify(body),
+    ...rest,
+  });
+  const data = (await response.json()) as T;
+
+  return { status: response.status, data };
+};
+
+describe('MSW 인증 핸들러', () => {
+  beforeEach(() => {
+    resetCertificationState();
+    resetProfileState();
+  });
+
+  it('카카오 OAuth URL을 반환한다', async () => {
+    const { status, data } = await requestJson<{ url: string }>(
+      '/api/v1/auth/kakao?redirectUri=https://kan.example.com/auth/kakao',
+    );
+
+    expect(status).toBe(200);
+    expect(data.url).toContain(
+      'redirect_uri=https://kan.example.com/auth/kakao',
+    );
+  });
+
+  it('인가 코드가 없으면 오류를 반환한다', async () => {
+    const { status, data } = await requestJson<{ error: { code: string } }>(
+      '/api/v1/auth/kakao/callback',
+    );
+
+    expect(status).toBe(400);
+    expect(data.error.code).toBe('AUTH_MISSING_CODE');
+  });
+
+  it('잘못된 인가 코드는 401 오류를 반환한다', async () => {
+    const { status, data } = await requestJson<{ error: { code: string } }>(
+      '/api/v1/auth/kakao/callback?code=invalid',
+    );
+
+    expect(status).toBe(401);
+    expect(data.error.code).toBe('AUTH_INVALID_CODE');
+  });
+
+  it('성공한 콜백은 토큰과 신규 회원 여부를 제공한다', async () => {
+    const { status, data } = await requestJson<{
+      accessToken: string;
+      refreshToken: string;
+      isNewMember: boolean;
+    }>('/api/v1/auth/kakao/callback?code=signup');
+
+    expect(status).toBe(200);
+    expect(data).toEqual({
+      accessToken: 'mock-access-token',
+      refreshToken: 'mock-refresh-token',
+      isNewMember: true,
+    });
+  });
+
+  it('기존 부산대학교 농구 회원은 로그인 시 신규 회원이 아니다', async () => {
+    const { status, data } = await requestJson<{
+      accessToken: string;
+      refreshToken: string;
+      isNewMember: boolean;
+    }>('/api/v1/auth/kakao/callback?code=signin');
+
+    expect(status).toBe(200);
+    expect(data).toEqual({
+      accessToken: 'mock-access-token',
+      refreshToken: 'mock-refresh-token',
+      isNewMember: false,
+    });
+  });
+});
+
+describe('MSW 이메일 인증 핸들러', () => {
+  beforeEach(() => {
+    resetCertificationState();
+  });
+
+  it('이메일 없이 요청하면 오류를 반환한다', async () => {
+    const { status, data } = await requestJson<{ error: { code: string } }>(
+      '/api/v1/members/me/certification/email',
+      { method: 'POST', body: {} },
+    );
+
+    expect(status).toBe(400);
+    expect(data.error.code).toBe('EMAIL_REQUIRED');
+  });
+
+  it('인증 이메일 요청 후 상태를 조회할 수 있다', async () => {
+    vi.useFakeTimers();
+    const sentAt = new Date('2024-01-01T10:00:00.000Z');
+    vi.setSystemTime(sentAt);
+
+    try {
+      const requestResult = await requestJson<{
+        email: string;
+        sentAt: string;
+      }>('/api/v1/members/me/certification/email', {
+        method: 'POST',
+        body: { email: 'user@kan.com' },
+      });
+
+      expect(requestResult.status).toBe(200);
+      expect(requestResult.data).toEqual({
+        email: 'user@kan.com',
+        sentAt: sentAt.toISOString(),
+      });
+
+      const statusResult = await requestJson<{
+        email: string | null;
+        verified: boolean;
+        lastSentAt: string | null;
+        verifiedAt: string | null;
+      }>('/api/v1/members/me/certification/status');
+
+      expect(statusResult.data).toEqual({
+        email: 'user@kan.com',
+        verified: false,
+        lastSentAt: sentAt.toISOString(),
+        verifiedAt: null,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('요청 없이 인증을 시도하면 오류를 반환한다', async () => {
+    const { status, data } = await requestJson<{ error: { code: string } }>(
+      '/api/v1/members/me/certification/verify',
+      { method: 'POST', body: { code: '000000' } },
+    );
+
+    expect(status).toBe(400);
+    expect(data.error.code).toBe('EMAIL_NOT_REQUESTED');
+  });
+
+  it('잘못된 인증 코드는 오류를 반환한다', async () => {
+    await requestJson('/api/v1/members/me/certification/email', {
+      method: 'POST',
+      body: { email: 'user@kan.com' },
+    });
+
+    const { status, data } = await requestJson<{ error: { code: string } }>(
+      '/api/v1/members/me/certification/verify',
+      { method: 'POST', body: { code: '123456' } },
+    );
+
+    expect(status).toBe(400);
+    expect(data.error.code).toBe('EMAIL_INVALID_TOKEN');
+  });
+
+  it('이미 인증된 이메일은 재요청 시 오류를 반환한다', async () => {
+    await requestJson('/api/v1/members/me/certification/email', {
+      method: 'POST',
+      body: { email: 'already@kan.com' },
+    });
+    await requestJson('/api/v1/members/me/certification/verify', {
+      method: 'POST',
+      body: { code: '000000' },
+    });
+
+    const { status, data } = await requestJson<{ error: { code: string } }>(
+      '/api/v1/members/me/certification/email',
+      { method: 'POST', body: { email: 'already@kan.com' } },
+    );
+
+    expect(status).toBe(409);
+    expect(data.error.code).toBe('EMAIL_ALREADY_VERIFIED');
+  });
+
+  it('발송 제한 이메일은 429 오류를 반환한다', async () => {
+    const { status, data } = await requestJson<{ error: { code: string } }>(
+      '/api/v1/members/me/certification/email',
+      { method: 'POST', body: { email: 'limit@kan.com' } },
+    );
+
+    expect(status).toBe(429);
+    expect(data.error.code).toBe('EMAIL_RATE_LIMITED');
+  });
+
+  it('인증에 성공하면 상태가 업데이트된다', async () => {
+    vi.useFakeTimers();
+    const sentAt = new Date('2024-01-01T10:00:00.000Z');
+    vi.setSystemTime(sentAt);
+
+    try {
+      await requestJson('/api/v1/members/me/certification/email', {
+        method: 'POST',
+        body: { email: 'user@kan.com' },
+      });
+
+      const verifiedAt = new Date('2024-01-01T10:05:00.000Z');
+      vi.setSystemTime(verifiedAt);
+
+      const verifyResult = await requestJson<{
+        email: string;
+        verifiedAt: string;
+      }>('/api/v1/members/me/certification/verify', {
+        method: 'POST',
+        body: { code: '000000' },
+      });
+
+      expect(verifyResult.status).toBe(200);
+      expect(verifyResult.data).toEqual({
+        email: 'user@kan.com',
+        verifiedAt: verifiedAt.toISOString(),
+      });
+
+      const statusResult = await requestJson<{
+        email: string | null;
+        verified: boolean;
+        lastSentAt: string | null;
+        verifiedAt: string | null;
+      }>('/api/v1/members/me/certification/status');
+
+      expect(statusResult.data).toEqual({
+        email: 'user@kan.com',
+        verified: true,
+        lastSentAt: sentAt.toISOString(),
+        verifiedAt: verifiedAt.toISOString(),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('MSW 프로필 핸들러', () => {
+  beforeEach(() => {
+    resetProfileState();
+  });
+
+  it('내 프로필을 조회할 수 있다', async () => {
+    const { status, data } = await requestJson<{
+      memberId: number;
+      name: string;
+    }>('/api/v2/members/me/profile');
+
+    expect(status).toBe(200);
+    expect(data).toMatchObject({
+      memberId: 101,
+      name: '김대영',
+    });
+  });
+
+  it('다른 사용자의 프로필을 조회할 수 있다', async () => {
+    const { status, data } = await requestJson<{
+      memberId: number;
+      name: string;
+    }>('/api/v2/members/102/profile');
+
+    expect(status).toBe(200);
+    expect(data).toMatchObject({
+      memberId: 102,
+      name: '부산대학교 리그',
+    });
+  });
+
+  it('존재하지 않는 사용자는 오류를 반환한다', async () => {
+    const { status, data } = await requestJson<{ error: { code: string } }>(
+      '/api/v2/members/999/profile',
+    );
+
+    expect(status).toBe(404);
+    expect(data.error.code).toBe('PROFILE_NOT_FOUND');
+  });
+
+  it('닉네임 업데이트에 성공하면 상태가 갱신된다', async () => {
+    const updateResult = await requestJson<{ name: string }>(
+      '/api/v2/members/me/profile/name',
+      { method: 'PATCH', body: { name: '부산대학교 농구 에이스' } },
+    );
+
+    expect(updateResult.status).toBe(200);
+    expect(updateResult.data.name).toBe('부산대학교 농구 에이스');
+
+    const profileResult = await requestJson<{ name: string }>(
+      '/api/v2/members/me/profile',
+    );
+
+    expect(profileResult.data.name).toBe('부산대학교 농구 에이스');
+  });
+
+  it('유효하지 않은 닉네임은 오류를 반환한다', async () => {
+    const { status, data } = await requestJson<{ error: { code: string } }>(
+      '/api/v2/members/me/profile/name',
+      { method: 'PATCH', body: { name: 'a' } },
+    );
+
+    expect(status).toBe(400);
+    expect(data.error.code).toBe('PROFILE_INVALID_NAME');
+  });
+
+  it('소개글은 150자 이하만 허용한다', async () => {
+    const { status, data } = await requestJson<{ error: { code: string } }>(
+      '/api/v2/members/me/profile/description',
+      { method: 'PATCH', body: { description: 'a'.repeat(151) } },
+    );
+
+    expect(status).toBe(400);
+    expect(data.error.code).toBe('PROFILE_INVALID_DESCRIPTION');
+  });
+
+  it('프로필 이미지는 유효한 URL만 허용한다', async () => {
+    const { status, data } = await requestJson<{ error: { code: string } }>(
+      '/api/v2/members/me/profile/image-url',
+      { method: 'PATCH', body: { imageUrl: 'invalid-url' } },
+    );
+
+    expect(status).toBe(400);
+    expect(data.error.code).toBe('PROFILE_INVALID_IMAGE_URL');
+  });
+
+  it('프로필 이미지를 업데이트하면 저장된다', async () => {
+    const updateResult = await requestJson<{ imageUrl: string }>(
+      '/api/v2/members/me/profile/image-url',
+      {
+        method: 'PATCH',
+        body: { imageUrl: 'https://example.com/avatar/new.png' },
+      },
+    );
+
+    expect(updateResult.status).toBe(200);
+    expect(updateResult.data.imageUrl).toBe(
+      'https://example.com/avatar/new.png',
+    );
+
+    const profileResult = await requestJson<{ imageUrl: string }>(
+      '/api/v2/members/me/profile',
+    );
+
+    expect(profileResult.data.imageUrl).toBe(
+      'https://example.com/avatar/new.png',
+    );
+  });
+});


### PR DESCRIPTION
## 📄 변경 사항 요약

- 카카오 OAuth URL 발급 및 콜백 처리 시나리오를 모킹하고, 인가 코드 누락·유효성 오류를 공통 에러 응답으로 반환하도록 구성
- 이메일 인증 상태를 메모리로 추적하는 더미 스토어와 리셋 함수를 두고, 이메일 전송·검증·상태 조회 엔드포인트를 성공/실패 케이스별로 모킹
- /api/greeting 와일드카드 요청에 대한 고정 응답을 불변 상수로 분리해 단일 공용 핸들러 배열로 정리
- 공통·인증·이메일 인증·프로필 핸들러를 한 배열로 합쳐 MSW 서버가 사용할 최종 핸들러 목록을 구성
- 부산대학교 농구 시나리오에 맞춘 기본 프로필 데이터와 리셋 로직을 정의하고, 자기소개/닉네임/이미지 수정 및 타 사용자 조회까지 포함한 프로필 API 흐름을 모킹
- 인증·이메일·프로필 전반에서 재사용할 에러 코드 카탈로그와 ApiErrorResponse 타입, 상태 코드와 메시지를 포함하는 응답 생성 유틸을 추가
- Vitest 전용 jest-dom 확장만 임포트하도록 조정하고, server.listen({ onUnhandledRequest: 'error' })을 단일 beforeAll 훅에서 호출하도록 정리
- axios 인스턴스를 통해 MSW 핸들러가 OAuth URL, 이메일 오류, 프로필 수정 시나리오를 올바르게 응답하는지 검증하는 통합 테스트를 작성
- 인증·이메일 인증·프로필 더미 흐름 전반을 한글 시나리오로 검증하고, fake timer를 활용해 sentAt/verifiedAt 값을 결정적으로 확인하는 통합 테스트 스위트를 구성

 
---

## ✅ PR 체크리스트

- [x] PR 제목은 변경 사항을 명확히 나타내나요?
- [x] `develop` 브랜치와 충돌이 없나요?
- [x] 로컬에서 충분히 테스트했나요?
- [x] 생성했던 Github의 이슈 번호를 기입해서 본문에 작성하셨나요?

---

## 🔗 관련 이슈

Closes #160 

---